### PR TITLE
Portable realpath

### DIFF
--- a/bin/direnv
+++ b/bin/direnv
@@ -8,7 +8,21 @@ usage() {
   echo "direnv export|exec|switch [options]" >&2
 }
 
-binpath=`readlink -f $0`
+realpath() {
+  local path=`readlink $1`
+
+  if [ -z $path ]; then
+    echo $1
+  else
+    if [[ $path = /* ]]; then
+      echo $path
+    else
+      echo $(realpath "$PWD/${path#./}")
+    fi
+  fi
+}
+
+binpath=$(realpath $0)
 bindir=`dirname "$binpath"`
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
`readlink -f` is GNU only, not available on BSD and OS X :(
