### PR TITLE
Fix `abs_dirname` to work with relative symlinks

### DIFF
--- a/bin/direnv
+++ b/bin/direnv
@@ -11,26 +11,22 @@ usage() {
 # usage: abs_dirname $filename
 # finds the original $filename path and prints it's absolute folder path
 abs_dirname() {
-  prev_path="$1"
+  orig_dir=`pwd`
+  path="$1"
   # Resolve the symlink(s) recursively
   while true; do
-    abs_path=`readlink "$prev_path" || true`
-    if [ -z "$abs_path" ]; then
-      abs_path="$prev_path"
+    cd `dirname "$path"`
+    path=`readlink "$path" || true`
+    if [ -z "$path" ]; then
       break
-    else
-      prev_path="$abs_path"
     fi
   done
-  unset prev_path
+  unset path
 
-  # Get the absolute directory of the final $abs_path
-  orig_dir=`pwd`
-  cd `dirname "$abs_path"`
   # prints an absolute path here
   pwd
   cd "$orig_dir"
-  unset abs_path orig_dir
+  unset orig_dir
 }
 
 bindir=`abs_dirname $0`


### PR DESCRIPTION
Finally got around to upgrading from shell-env to direnv :)

We need to `cd` after resolving every symlink along the way. Just `cd`ing at the end could mean trying to change into a relative path that doesn't exist at your current working directory.

This implementation is slightly simpler too.

Heres my setup:

```
$ ls -al /usr/local/bin/direnv
lrwxr-xr-x  1 josh  staff    31B May 28 11:18 /usr/local/bin/direnv@ -> ../Cellar/direnv/453/bin/direnv

$ ls -al /usr/local/Cellar/direnv/453/bin/direnv
-rwxrwxrwx  1 josh  staff   682B May 28 11:38 /usr/local/Cellar/direnv/453/bin/direnv*
```
