### PR TITLE
Don't export PROMPT_COMMAND

### DIFF
--- a/libexec/direnv-hook
+++ b/libexec/direnv-hook
@@ -23,7 +23,7 @@ fi
 # More of them here: http://www.linux.org/docs/ldp/howto/Xterm-Title-4.html
 if [ "$target" = "bash" ]; then
   cat <<HOOK
-export PROMPT_COMMAND="eval \\\`direnv export\\\`;\$PROMPT_COMMAND"
+PROMPT_COMMAND="eval \\\`direnv export\\\`;\$PROMPT_COMMAND"
 HOOK
 elif [ "$target" = "zsh" ]; then
   cat <<HOOK


### PR DESCRIPTION
I ran into this issue on Lion Terminal.app. It sets `PROMPT_COMMAND=update_terminal_cwd` which is correctly updated to `PROMPT_COMMAND=eval direnv export; update_terminal_cwd;`. However `update_terminal_cwd` isn't always available in sub shells.

Since `PROMPT_COMMAND` isn't exported by default it seems proper to leave it local to the environment. And if people want to, they can always export it themselves.
