### PR TITLE
compatibility with Linux stat

### DIFF
--- a/libexec/direnv-export
+++ b/libexec/direnv-export
@@ -22,7 +22,11 @@ direnv_find_rc() {
 
 if direnv_find_rc; then
   unset direnv_find_rc
-  eval `stat -s $PWD/.envrc`
+  if [ $(uname) = Linux ]; then
+    st_mtime=`stat -c '%Y' "$PWD/.envrc"`
+  else
+    eval `stat -s $PWD/.envrc`
+  fi
   if [ -n "$DIRENV_BACKUP" ]; then
     if [ "$DIRENV_DIR" = "`pwd`" ] && [ "$st_mtime" -le "${DIRENV_MTIME:-0}" ]; then
       # env already loaded


### PR DESCRIPTION
stat from GNU coreutils 7.4 (as on Ubuntu 10.4) does not have -s option
replace with st_mtime=`stat -c '%Y' .envrc`,
on OS X, stat -f '%m' would achieve the same

this change was tested on Ubuntu 10.4 and OS X 10.7
