### PR TITLE
unload .envrc when directly jumping from one directory with .envrc to another

### DIFF
--- a/libexec/direnv-export
+++ b/libexec/direnv-export
@@ -31,6 +31,9 @@ if direnv_find_rc; then
     if [ "$DIRENV_DIR" = "`pwd`" ] && [ "$st_mtime" -le "${DIRENV_MTIME:-0}" ]; then
       # env already loaded
       exit 0
+    else
+      echo "direnv: unloading $DIRENV_DIR" >&2
+      direnv diff "$DIRENV_BACKUP"
     fi
     eval `direnv diff "$DIRENV_BACKUP"`
   fi


### PR DESCRIPTION
unload .envrc when directly jumping from one directory with .envrc to another

before, only the the .envrc from the new directory would be loaded on
top of the one in the old directory
