### PR TITLE
Fixes eval parsing error in direnv-hook for zsh

### DIFF
--- a/libexec/direnv-hook
+++ b/libexec/direnv-hook
@@ -35,7 +35,7 @@ zsh)
   cat <<HOOK
 direnv_hook() {
   eval \`direnv export\`
-}
+};
 [[ -z \$precmd_functions ]] && precmd_functions=()
 precmd_functions=(\$precmd_functions direnv_hook)
 HOOK


### PR DESCRIPTION
Recent addition that moves hook into `precmd_functions` introduced a syntax error, one that's easily fixed with the addition of a semicolon.
