### PR TITLE
Fix eval parsing errors in direnv-hook for zsh

### DIFF
--- a/libexec/direnv-hook
+++ b/libexec/direnv-hook
@@ -33,7 +33,7 @@ HOOK
   ;;
 zsh)
   cat <<HOOK
-function direnv_hook {
+direnv_hook() {
   eval \`direnv export\`
 };
 [[ -z \$precmd_functions ]] && precmd_functions=();


### PR DESCRIPTION
Zsh hook definition fails unless eval'd code has semicolons. Patch fixes this problem.
