### PR TITLE
Avoid problems caused by zsh globsubst option

### DIFF
--- a/libexec/direnv-hook
+++ b/libexec/direnv-hook
@@ -32,11 +32,14 @@ HOOK
   ;;
 zsh)
   cat <<HOOK
+globsubst=\`setopt | grep globsubst\`;
+unsetopt globsubst;
 direnv_hook() {
   eval \`$DIRENV_LIBEXEC/direnv-export\`
 };
 [[ -z \$precmd_functions ]] && precmd_functions=();
-precmd_functions=(\$precmd_functions direnv_hook)
+precmd_functions=(\$precmd_functions direnv_hook);
+[[ -n \$globsubst ]] && setopt globsubst
 HOOK
   ;;
 *)


### PR DESCRIPTION
When the shell has the globsubst option enabled,
the function definition throws an error, and the
hook never gets defined.
