### PR TITLE
Proposal: Add general warning to all commands if they take longer than 2s

### DIFF
--- a/direnv.go
+++ b/direnv.go
@@ -2,14 +2,27 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"time"
 )
 
 func main() {
 	env := GetEnv()
 
-	if err := CommandsDispatch(env, os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "direnv %s: %s\n", os.Args[1], err)
+	done := make(chan bool, 1)
+	go func() {
+		select {
+		case <-done:
+			return
+		case <-time.After(2 * time.Second):
+			log.Printf("direnv(%v) is taking a while to execute. Use CTRL-C to give up.", os.Args)
+		}
+	}()
+
+	err := CommandsDispatch(env, os.Args)
+	done <- true
+	if err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This is a proposal for discussion, I don't mind if it is discarded.

I was thinking that something like this could help the user in the case when they start bash and it appears to be frozen, which can happen if they're on a network 
filesystem.

It introduces a warning currently when any direnv command takes longer than 2s to execute.
