### PR TITLE
Add `direnv invoke WORKDIR EXECUTABLE [ARGS...]`

### DIFF
--- a/cmd_invoke.go
+++ b/cmd_invoke.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+var CmdInvoke = &Cmd{
+	Name: "invoke",
+	Desc: "run EXECUTABLE with appropriate environment for WORKDIR",
+	Args: []string{"WORKDIR EXECUTABLE [ARGS...]"},
+	Fn: func(env Env, args []string) (err error) {
+
+		flagset := flag.NewFlagSet(args[0], flag.ExitOnError)
+		flagset.Parse(args[1:])
+
+		workdir := flagset.Arg(0)
+		if workdir == "" {
+			return fmt.Errorf("WORKDIR missing")
+		}
+		program := flagset.Args()[1:]
+		if len(program) < 1 {
+			return fmt.Errorf("EXECUTABLE missing")
+		}
+
+		var config *Config
+		if config, err = LoadConfig(env); err != nil {
+			return
+		}
+
+		script := `
+	        DIRENV_PATH="%s"
+    	    eval "$(${DIRENV_PATH} export bash)"    
+    	    exec "$@"
+	    `
+		script = fmt.Sprintf(script, config.SelfPath)
+
+		// Invoke `bash -c "eval \"$($DIRENV export bash)\"; exec $@" -- program [args]`
+		// in the destination directory so as to have the correct environment
+		bash_args := append([]string{"-c", script, "--"}, program...)
+
+		err = Invoke(workdir, bash_args)
+		return err
+	},
+}

--- a/cmd_invoke_nonposix.go
+++ b/cmd_invoke_nonposix.go
@@ -1,0 +1,24 @@
+// Not a system which supports Exec(). See cmd_invoke_posix for Exec() impl.
+// +build !darwin,!freebsd,!linux,!netbsd,!openbsd
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func Invoke(dir string, bash_args []string) (err error) {
+	fmt.Println("Non-exec invoke")
+	cmd := exec.Command("bash", bash_args...)
+	cmd.Dir = dir
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		err = fmt.Errorf("Failed to invoke shell: %q", err)
+	}
+	return err
+}

--- a/cmd_invoke_posix.go
+++ b/cmd_invoke_posix.go
@@ -1,0 +1,29 @@
+// Systems which support Exec(). See cmd_invoke_nonposix for non-Exec() impl.
+// +build darwin freebsd linux netbsd openbsd
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// Exec into target process.
+func Invoke(dir string, bash_args []string) (err error) {
+	e := os.Chdir(dir)
+	if e != nil {
+		return e
+	}
+
+	arg0, err := exec.LookPath("bash")
+	if err != nil {
+		return fmt.Errorf("Can't find bash: %q", err)
+	}
+
+	argv := append([]string{arg0}, bash_args...)
+	err = syscall.Exec(arg0, argv, os.Environ())
+	// Note, remember Exec will never return unless there is an error.
+	return err
+}

--- a/commands.go
+++ b/commands.go
@@ -29,6 +29,7 @@ func init() {
 		CmdExport,
 		CmdHelp,
 		CmdHook,
+		CmdInvoke,
 		CmdReload,
 		CmdStatus,
 		CmdStdlib,


### PR DESCRIPTION
Does what you might imagine. Establishes the direnv environment for `$WORKDIR`
before running `$EXECUTABLE $ARGS`.

On platforms where exec is available, we exec into the target executable.
Otherwise `os/exec.Command()` is used.
