### PR TITLE
DIRENV_* variables are reseted when you cd to directory with .envrc

### DIFF
--- a/env.go
+++ b/env.go
@@ -51,12 +51,14 @@ func EnvDiff(env1 map[string]string, env2 map[string]string) Env {
 
 // A list of keys we don't want to deal with
 var IGNORED_KEYS = map[string]bool{
-	"OLDPWD": true,
-	"PS1":    true,
-	"PWD":    true,
-	"SHELL":  true,
-	"SHLVL":  true,
-	"_":      true,
+	"OLDPWD":        true,
+	"PS1":           true,
+	"PWD":           true,
+	"SHELL":         true,
+	"SHLVL":         true,
+	"_":             true,
+	"DIRENV_CONFIG": true,
+	"DIRENV_BASH":   true,
 }
 
 func ignoredKey(key string) bool {


### PR DESCRIPTION
Hello,
I encountered the problem with setting special DIRENV_\* variables.
They're reseted when you cd to directory with .envrc.

How to reproduce:

```
$ cd ~
~
$ export DIRENV_CONFIG=~/.direnv; env | grep DIRENV_CONFIG
DIRENV_CONFIG=/Users/ardecvz/.direnv
$ cd ~/dir_with_envrc
.envrc is blocked from loading. Run `direnv allow` to approve it's content for loading.
$ env | grep DIRENV_CONFIG
# Nothing, but it should output DIRENV_CONFIG=/Users/ardecvz/.direnv
$ cd ~
direnv: unloading
$ env | grep DIRENV_CONFIG
# Nothing, but it should output DIRENV_CONFIG=/Users/ardecvz/.direnv again
```

So direnv resets previously set variables. It doesn't matter if you execute direnv allow or not.
As I understand, these variables (DIRENV_CONFIG, DIRENV_BASH and so on) exist to tune your installation so it should be kept to the new env created by direnv.

I have zero knowledge of Go but you should pay attention to this code in env.go:92

``` go
func (env Env) Filtered() Env {
    newEnv := make(Env)

    for key, value := range env {
        if !ignoredKey(key) && !direnvVar(key) {
            newEnv[key] = value
        }
    }

    return newEnv
}
```

It filters _ALL_ service variables. There's no separation of user defined and internal DIRENV_\* variables.

As a quick fix to keep special DIRENV_\* variables we may add them to the ignore list.
