### PR TITLE
allow `direnv dump` to be run from any process run by .envrc

### DIFF
--- a/cmd_dump.go
+++ b/cmd_dump.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"os"
 )
 
 // `direnv dump`
@@ -10,7 +12,18 @@ var CmdDump = &Cmd{
 	Desc:    "Used to export the inner bash state at the end of execution",
 	Private: true,
 	Fn: func(env Env, args []string) (err error) {
-		fmt.Println(env.Filtered().Serialize())
+		output := os.NewFile(uintptr(3), "DIRENV_DUMP_FD")
+
+		_, err = io.WriteString(output, env.Filtered().Serialize())
+		if err != nil {
+			return fmt.Errorf("dump: %v", err)
+		}
+
+		_, err = output.Write([]byte{0, '\n'})
+		if err != nil {
+			return fmt.Errorf("dump: %v", err)
+		}
+
 		return
 	},
 }

--- a/env.go
+++ b/env.go
@@ -115,8 +115,6 @@ func (env Env) ToGoEnv() []string {
 }
 
 func ParseEnv(base64env string) (Env, error) {
-	base64env = strings.TrimSpace(base64env)
-
 	zlibData, err := base64.URLEncoding.DecodeString(base64env)
 	if err != nil {
 		return nil, fmt.Errorf("ParseEnv() base64 decoding: %v", err)

--- a/test/direnv-test.sh
+++ b/test/direnv-test.sh
@@ -69,6 +69,13 @@ test_start "space dir"
   test "$SPACE_DIR" = "true"
 test_stop
 
+test_start "child-env"
+  direnv_eval
+  test "$PARENT_PRE" = "1"
+  test "$CHILD" = "1"
+  test -z "$PARENT_POST"
+test_stop
+
 test_start "special-vars"
   export DIRENV_BASH=`which bash`
   export DIRENV_CONFIG=foobar

--- a/test/scenarios/child-env/.envrc
+++ b/test/scenarios/child-env/.envrc
@@ -1,0 +1,4 @@
+export PARENT_PRE=1
+bash -c 'export CHILD=1; direnv dump'
+# should be ignored, since `direnv dump` has already happened
+export PARENT_POST=1


### PR DESCRIPTION
`direnv dump` now terminates with a null byte (chosen simply because it definitely won't appear in regular base64-encoded dump output). Also, `direnv dump` always writes to FD 3, which is a pipe set up by the process loading the .envrc.

When the parent process reads the dumped environment, it uses only the _first_ dump (up to the first null byte) - any further dumps are ignored. This allows the user to dump a different process' environment, which is useful with tools that work in sub-processes. For example:

```
# .envrc
0install run \
    http://gfxmonk.net/dist/0install/0env.xml \
    http://gfxmonk.net/dist/0install/mocktest.xml \
    -- direnv dump
```

This sets up all the required environment variables in a subprocess, then runs `direnv dump` in that process.

This implements the feature I requested in #85.

Apologies for any failure to follow go-isms, this is my second ever patch to go code ;)
