### PR TITLE
Readme note that the Go language is required for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ make install
 # or symlink bin/direnv into your $PATH
 ```
 
-For Mac users, you can also use `brew install direnv`
+Installing from the repository requires the Go language.
+
+For Homebrew users, you can also use `brew install direnv`
+
+For MacPorts users, install Go with `sudo port install go`, then install from the repository.
 
 ### 2. Add the hook for your shell
 


### PR DESCRIPTION
It's not obvious to new users (i.e. me) that the Go language is required for installation. With MacPorts, I had to install it first before it would work, otherwise I would get this when trying to `make install`:

```
go fmt
make: go: No such file or directory
make: *** [direnv] Error 1
```

The note is also useful because I happen to know the Go language but I know many developers who have never heard of it and so wouldn't have a clue what the problem is.
