### PR TITLE
Set the executable bit on direnv.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,6 @@ release: build
 install: all
 	install -d bin $(DESTDIR)/bin
 	install -d man $(DESTDIR)/share/man/man1
-	cp direnv $(DESTDIR)/bin
+	install direnv $(DESTDIR)/bin
 	cp -R man/*.1 $(DESTDIR)/share/man/man1
 


### PR DESCRIPTION
make install was not setting the executable bit on direnv. I changed the Makefile to use the install command to copy direnv into place. The install command sets the executable bit.
