### PR TITLE
Fix error in manpage

### DIFF
--- a/man/direnv.1
+++ b/man/direnv.1
@@ -28,7 +28,7 @@ bin/ lib/ Rakefile README\.md
 $ echo $PATH
 /usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin
 $ echo PATH_add bin > \.envrc
-\.envrc is not allowed
+\&.envrc is not allowed
 $ direnv allow
 direnv: reloading
 direnv: loading \.envrc


### PR DESCRIPTION
To start a line with '.' in manpage it should be preceded with the
empty space escape sequence '&'. Fix this in the direnv manpage
