### PR TITLE
Support for Cygwin

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 )
 
 type Config struct {
@@ -40,6 +41,7 @@ func LoadConfig(env Env) (config *Config, err error) {
 		err = fmt.Errorf("LoadConfig() symlink resolution: %q", err)
 		return
 	}
+	exePath = strings.Replace(exePath, "\\", "/", -1)
 	config.SelfPath = exePath
 
 	config.BashPath = env[DIRENV_BASH]

--- a/script/release
+++ b/script/release
@@ -14,9 +14,13 @@ cd `dirname $0`/..
 mkdir -p release
 
 for PLATFORM in $PLATFORMS; do
+  EXTENSION=
   export GOOS=${PLATFORM%/*}
   export GOARCH=${PLATFORM#*/}
-  CMD="go build -o release/$OUTPUT.${GOOS}-${GOARCH}"
+  if [ $GOOS = "windows" ] ; then
+    EXTENSION=".exe"
+  fi
+  CMD="go build -o release/$OUTPUT.${GOOS}-${GOARCH}${EXTENSION}"
   echo "GOOS=${GOOS} GOARCH=${GOARCH} $CMD"
   $CMD
 done


### PR DESCRIPTION
1. Ensure paths are always forward slashes.
2. Ensure Windows releases have the .exe extension
