### PR TITLE
Resolve symbolic links to load envrc in parent dirs

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -130,8 +130,10 @@ source_env() {
     rcpath="$rcpath/.envrc"
   fi
   log_status "loading $rcfile"
-  pushd "$(dirname "$rcpath")" > /dev/null
-  . "./$(basename "$rcpath")"
+  pushd "$(pwd -P 2>/dev/null)" > /dev/null
+    pushd "$(dirname "$rcpath")" > /dev/null
+    . "./$(basename "$rcpath")"
+    popd > /dev/null
   popd > /dev/null
 }
 


### PR DESCRIPTION
Hello.
I tried to fix a issue that `direnv` failed to load `.envrc` when one moved to symbolic link to directory.

That is:

```
$ mkdir ~/gocode-foo/src/github.com/user/foo
$ touch ~/gocode-foo/.envrc
$ ln -s ~/gocode-foo/src/github.com/user/foo ~/foo
$ cd ~/foo
direnv: loading ../../../../.envrc
/bin/bash: line 133: ./.envrc: No such file or directory
```

This is important especially for go-lang and `layout go` users.

Thanks.
