### PR TITLE
Fix dotenv with explicit .env

### DIFF
--- a/cmd_dotenv.go
+++ b/cmd_dotenv.go
@@ -56,7 +56,7 @@ var CmdDotEnv = &Cmd{
 		}
 
 		if len(args) > 2 {
-			target = args[1]
+			target = args[2]
 		}
 
 		if target == "" {


### PR DESCRIPTION
If the dotenv command is used with a parameter (like "dotenv src/.env"),
it doesn't work with the following error message:

direnv: error open bash: no such file or directory

This commit makes it use the correct parameter for the target file.
