### PR TITLE
Remove unnecessary virtualenv options

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -282,7 +282,7 @@ layout_perl() {
 layout_python() {
   export VIRTUAL_ENV=$PWD/.direnv/virtualenv
   if ! [ -d "$VIRTUAL_ENV" ]; then
-    virtualenv --no-site-packages --distribute "$VIRTUAL_ENV"
+    virtualenv "$VIRTUAL_ENV"
   fi
   virtualenv --relocatable "$VIRTUAL_ENV" >/dev/null
   PATH_add "$VIRTUAL_ENV/bin"


### PR DESCRIPTION
`--distribute` is now a no-op since the merge of distribute back into setuptools.
`--no-site-packages` is now the default.
