### PR TITLE
Add a python3 layout

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -294,7 +294,7 @@ layout_python() {
 # Uses the system's installation of Python 3.
 # This forces the installation of any egg into the project's sub-folder.
 #
-layout_python() {
+layout_python3() {
   export VIRTUAL_ENV=$PWD/.direnv/virtualenv
   PYTHON=`which python3`
   if ! [ -d "$VIRTUAL_ENV" ]; then


### PR DESCRIPTION
Create a virtualenv with the system version of Python 3.

This picks a user's `python3` from the path which may not be the 3.x version they want but provides a simple base.
