### PR TITLE
Python layout option

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -165,15 +165,18 @@ Adds "$PWD/node_modules/.bin" to the PATH environment variable.
 \fB\fClayout perl\fR:
 Setup environment variables required by perl's local::lib
 See 
-.UR http://search.cpan.org/dist/local-lib/lib/local/lib.pm
-.UE
-for more
+\[la]http://search.cpan.org/dist/local-lib/lib/local/lib.pm\[ra] for more
 details
 .IP \(bu 2
 \fB\fClayout python\fR [\fIpython_exe\fP]:
-Creates and loads a virtualenv environment under \fB\fC$PWD/.direnv/virtualenv\fR\&. This forces the installation of any egg into the project's sub\-folder.
+Creates and loads a virtualenv environment under \fB\fC$PWD/.direnv/python\-$python_version\fR\&. This forces the installation of any egg into the project's sub\-folder.
 .PP
 It's possible to specify the python executable if you want to use different versions of python (eg: \fB\fClayout python python3\fR).
+.PP
+Note that previously virtualenv was located under \fB\fC$PWD/.direnv/virtualenv\fR and will be re\-used by direnv if it exists.
+.IP \(bu 2
+\fB\fClayout python3\fR:
+A shortcut for \fB\fClayout python python3\fR
 .IP \(bu 2
 \fB\fClayout ruby\fR:
 Sets the GEM\fIHOME environment variable to `$PWD/.direnv/ruby/RUBY\fPVERSION\fB\fC\&. This forces the installation of any gems into the project's sub\-folder.
@@ -205,9 +208,7 @@ Should work just like in the shell if you have rvm installed.
 .SH COPYRIGHT
 .PP
 Copyright (C) 2014 zimbatm 
-.UR http://zimbatm.com
-.UE
-and contributors under the MIT licence.
+\[la]http://zimbatm.com\[ra] and contributors under the MIT licence.
 .SH SEE ALSO
 .PP
 .BR direnv (1)

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -130,9 +130,14 @@ Example:
     details
 
 * `layout python` [*python_exe*]:
-    Creates and loads a virtualenv environment under `$PWD/.direnv/virtualenv`. This forces the installation of any egg into the project's sub-folder.
+    Creates and loads a virtualenv environment under `$PWD/.direnv/python-$python_version`. This forces the installation of any egg into the project's sub-folder.
 
     It's possible to specify the python executable if you want to use different versions of python (eg: `layout python python3`).
+
+    Note that previously virtualenv was located under `$PWD/.direnv/virtualenv` and will be re-used by direnv if it exists.
+
+* `layout python3`:
+    A shortcut for `layout python python3`
 
 * `layout ruby`:
     Sets the GEM_HOME environment variable to `$PWD/.direnv/ruby/RUBY_VERSION`. This forces the installation of any gems into the project's sub-folder.

--- a/stdlib.go
+++ b/stdlib.go
@@ -280,19 +280,24 @@ const STDLIB = "# These are the commands available in an .envrc context\n" +
 	"\n" +
 	"# Usage: layout python <python_exe>\n" +
 	"#\n" +
-	"# Creates and loads a virtualenv environment under \"$PWD/.direnv/virtualenv\".\n" +
+	"# Creates and loads a virtualenv environment under\n" +
+	"# \"$PWD/.direnv/python-$python_version\".\n" +
 	"# This forces the installation of any egg into the project's sub-folder.\n" +
 	"#\n" +
 	"# It's possible to specify the python executable if you want to use different\n" +
 	"# versions of python.\n" +
 	"#\n" +
 	"layout_python() {\n" +
-	"  export VIRTUAL_ENV=$PWD/.direnv/virtualenv\n" +
-	"  if [ -n \"$1\" ]; then\n" +
-	"    args=\"--python=$1\"\n" +
-	"  fi\n" +
-	"  if ! [ -d \"$VIRTUAL_ENV\" ]; then\n" +
-	"    virtualenv $args \"$VIRTUAL_ENV\"\n" +
+	"  local python=\"${1:-python}\"\n" +
+	"  local old_env=\"$PWD/.direnv/virtualenv\"\n" +
+	"  if [[ -d $old_env && $python = \"python\" ]]; then\n" +
+	"    export VIRTUAL_ENV=\"$old_virtualenv\"\n" +
+	"  else\n" +
+	"    local python_version=$(\"$python\" -c \"import platform as p;print(p.python_version())\")\n" +
+	"    export VIRTUAL_ENV=\"$PWD/.direnv/python-$python_version\"\n" +
+	"    if [[ ! -d $VIRTUAL_ENV ]]; then\n" +
+	"      virtualenv \"--python=$python\" \"$VIRTUAL_ENV\"\n" +
+	"    fi\n" +
 	"  fi\n" +
 	"  virtualenv --relocatable \"$VIRTUAL_ENV\" >/dev/null\n" +
 	"  PATH_add \"$VIRTUAL_ENV/bin\"\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -278,19 +278,24 @@ layout_perl() {
 
 # Usage: layout python <python_exe>
 #
-# Creates and loads a virtualenv environment under "$PWD/.direnv/virtualenv".
+# Creates and loads a virtualenv environment under
+# "$PWD/.direnv/python-$python_version".
 # This forces the installation of any egg into the project's sub-folder.
 #
 # It's possible to specify the python executable if you want to use different
 # versions of python.
 #
 layout_python() {
-  export VIRTUAL_ENV=$PWD/.direnv/virtualenv
-  if [ -n "$1" ]; then
-    args="--python=$1"
-  fi
-  if ! [ -d "$VIRTUAL_ENV" ]; then
-    virtualenv $args "$VIRTUAL_ENV"
+  local python="${1:-python}"
+  local old_env="$PWD/.direnv/virtualenv"
+  if [[ -d $old_env && $python = "python" ]]; then
+    export VIRTUAL_ENV="$old_virtualenv"
+  else
+    local python_version=$("$python" -c "import platform as p;print(p.python_version())")
+    export VIRTUAL_ENV="$PWD/.direnv/python-$python_version"
+    if [[ ! -d $VIRTUAL_ENV ]]; then
+      virtualenv "--python=$python" "$VIRTUAL_ENV"
+    fi
   fi
   virtualenv --relocatable "$VIRTUAL_ENV" >/dev/null
   PATH_add "$VIRTUAL_ENV/bin"


### PR DESCRIPTION
Adds more flexibility to the python layout. See #135

It's not finished yet. We should change the virtualenv path to `.direnv/python/<python_version>`. That would make version switching convenient ; typically while developing a library it is a desirable feature to allow easy version switching for testing. This would break backward-compatiblity a bit and direnv users of the feature would have to re-build their virtualenv.
