### PR TITLE
Don't make Python virtualenvs relocatable

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -297,7 +297,6 @@ layout_python() {
       virtualenv "--python=$python" "$VIRTUAL_ENV"
     fi
   fi
-  virtualenv --relocatable "$VIRTUAL_ENV" >/dev/null
   PATH_add "$VIRTUAL_ENV/bin"
 }
 


### PR DESCRIPTION
I found making a virtualenv relocatable with Python 3.4 meant my site-packages got linked in. I've removed the relocatable line from both python layouts in anticipation for #136.

I'm not sure why relocatable would do this but I also wouldn't typically make a virtualenv relocatble normally. What was your reasoning for making the virtualenvs relocatable?
