### PR TITLE
Use add-zsh-hook

### DIFF
--- a/shell_zsh.go
+++ b/shell_zsh.go
@@ -9,9 +9,9 @@ const ZSH_HOOK = `
 _direnv_hook() {
   eval "$(direnv export zsh)";
 }
-typeset -a precmd_functions
+autoload -U add-zsh-hook
 if [[ -z $precmd_functions[(r)_direnv_hook] ]]; then
-  precmd_functions+=_direnv_hook;
+  add-zsh-hook precmd _direnv_hook;
 fi
 `
 


### PR DESCRIPTION
_direnv_hook is appended to local variable when called from a function.

``` bash
# before
% _my_hooks() { eval "$(direnv hook zsh)"; }; _my_hooks
% echo $precmd_functions

```

``` bash
# after
% _my_hooks() { eval "$(direnv hook zsh)"; }; _my_hooks
% echo $precmd_functions
_direnv_hook
```
