### PR TITLE
Add ability to prune references to .envrc, which no more exists

### DIFF
--- a/cmd_prune.go
+++ b/cmd_prune.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+var CmdPrune = &Cmd{
+	Name: "prune",
+	Desc: "prune allowed .envrc's which no more exists",
+	Fn: func(env Env, args []string) (err error) {
+		var config *Config
+		var dir *os.File
+		var fi os.FileInfo
+		var dir_list []string
+		var envrc []byte
+
+		if config, err = LoadConfig(env); err != nil {
+			return err
+		}
+
+		allowed := config.AllowDir()
+		if dir, err = os.Open(allowed); err != nil {
+			return err
+		}
+		defer dir.Close()
+
+		if dir_list, err = dir.Readdirnames(0); err != nil {
+			return err
+		}
+
+		for _, hash := range dir_list {
+			filename := path.Join(allowed, hash)
+			if fi, err = os.Stat(filename); err != nil {
+				return err
+			}
+
+			if !fi.IsDir() {
+				if envrc, err = ioutil.ReadFile(filename); err != nil {
+					return err
+				}
+				envrc_str := strings.TrimSpace(string(envrc))
+
+				// skip old files, w/o path inside
+				if envrc_str == "" {
+					continue
+				}
+				if !fileExists(envrc_str) {
+					_ = os.Remove(filename)
+				}
+
+			}
+
+		}
+		return nil
+	},
+}

--- a/commands.go
+++ b/commands.go
@@ -31,6 +31,7 @@ func init() {
 		CmdExport,
 		CmdHelp,
 		CmdHook,
+		CmdPrune,
 		CmdReload,
 		CmdStatus,
 		CmdStdlib,

--- a/rc.go
+++ b/rc.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -58,7 +59,7 @@ func (self *RC) Allow() (err error) {
 	if err = os.MkdirAll(filepath.Dir(self.allowPath), 0755); err != nil {
 		return
 	}
-	if err = touch(self.allowPath); err != nil {
+	if err = allow(self.path, self.allowPath); err != nil {
 		return
 	}
 	self.mtime, err = fileMtime(self.allowPath)
@@ -205,14 +206,12 @@ func fileHash(path string) (hash string, err error) {
 // Creates a file
 
 func touch(path string) (err error) {
-	file, err := os.OpenFile(path, os.O_CREATE, 0644)
-	if err != nil {
-		return
-	}
-	file.Close()
-
 	t := time.Now()
 	return os.Chtimes(path, t, t)
+}
+
+func allow(path string, allowPath string) (err error) {
+	return ioutil.WriteFile(allowPath, []byte(path+"\n"), 0644)
 }
 
 func findUp(searchDir string, fileName string) (path string) {


### PR DESCRIPTION
The problem:

When we enable reading  .envrc with  `direnv allow` command, we create empty file in .config/direnv/allow/, but when we remove entrie directory with .envrc, "allow hash" still exists.

Solution:
I add code to store path to .envrc in "allow-hash" file, and implement `prune` subcommand, which remove stalled files from .config/direnv/allow (old empty files still be untouched)