### PR TITLE
Added SHELLOPTS to ignored vars

### DIFF
--- a/env_diff.go
+++ b/env_diff.go
@@ -17,6 +17,7 @@ var IGNORED_KEYS = map[string]bool{
 	"OLDPWD": true,
 	"PWD":    true,
 	"SHELL":  true,
+	"SHELLOPTS": true,
 	"SHLVL":  true,
 	"_":      true,
 }


### PR DESCRIPTION
I have problems using a modified SHELLOPTS with cygwin and zsh.
When I go to any .envrc folder this VAR is modified and is added to direnv managed vars.

Example:
➜  git $  echo $SHELLOPTS
igncr

➜  git $ cd xxxx
direnv: loading C:\Users\xxxxx\Documents\git\xxxx\.envrc
direnv: loading .envrc.mine
direnv: loading .envrc.xxxx-xxxx
direnv: export +SPARQL_REPOSITORY_URL ~SHELLOPTS

➜  xxxx git:(develop) ✗ $ echo $SHELLOPTS
braceexpand:errexit:hashall:igncr:interactive-comments

➜  xxxx git:(develop) ✗ $ cd ..
direnv: unloading

➜  git  $ echo $SHELLOPTS
igncr

Consider add this variable to ignored vars list