### PR TITLE
Add support for emacs export

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -26,12 +26,14 @@ func DetectShell(target string) Shell {
 		return BASH
 	case "zsh":
 		return ZSH
+	case "tcsh":
+		return TCSH
 	case "fish":
 		return FISH
 	case "vim":
 		return VIM
-	case "tcsh":
-		return TCSH
+	case "emacs":
+		return EMACS
 	}
 
 	return nil

--- a/shell_emacs.go
+++ b/shell_emacs.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+type emacs int
+
+var EMACS emacs
+
+func (x emacs) Hook() string {
+	log_error("this feature is not supported. Install the direnv.el plugin instead.")
+	os.Exit(1)
+	return ""
+}
+
+func (x emacs) Escape(str string) string {
+	str = strings.Replace(str, "\\", "\\\\", -1)
+	str = strings.Replace(str, "\"", "\\\"", -1)
+	return "\"" + str + "\""
+}
+
+func (x emacs) Export(key, value string) string {
+	return "(setenv " + x.Escape(key) + " " + x.Escape(value) + ")\n"
+}
+
+func (x emacs) Unset(key string) string {
+	return "(setenv " + x.Escape(key) + " nil)\n"
+}


### PR DESCRIPTION
At some point I would like to add a universal format that can be understood by all shells instead.

The emacs.el script is still under construction, I never did any lisp so it may take a while.