### PR TITLE
Remove reference to ~/.config/direnv/direnvrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ To find the documentation for all available functions check the
 direnv-stdlib(1) man page.
 
 It's also possible to create your own extensions by creating a bash file at
-"~/.config/direnv/direnvrc" or "~/.direnvrc". This file is loaded before your
-".envrc" and thus allows you to make your own extensions to direnv.
+"~/.direnvrc". This file is loaded before your ".envrc" and thus allows you
+to make your own extensions to direnv.
 
 #### Loading layered .envrc
 


### PR DESCRIPTION
It looks like this file is never loaded, and the path is not mentioned anywhere in the code (as far as I can tell). So I assume it's a remnant from some older version where this was supported.