### PR TITLE
Add use_nix() helper to stdlib

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -380,6 +380,17 @@ const STDLIB = "# These are the commands available in an .envrc context\n" +
 	"  rvm \"$@\"\n" +
 	"}\n" +
 	"\n" +
+	"# Usage: use_nix [...]\n" +
+	"#\n" +
+	"# Load environment variables from `nix-shell`.\n" +
+	"# If you have a `default.nix` or `shell.nix` these will be\n" +
+	"# used by default, but you can also specify packages directly\n" +
+	"# (e.g `use nix -p ocaml`).\n" +
+	"#\n" +
+	"use_nix() {\n" +
+	"  direnv_load nix-shell --show-trace \"$@\" --run 'direnv dump'\n" +
+	"}\n" +
+	"\n" +
 	"## Load the global ~/.direnvrc if present\n" +
 	"if [ -f \"$HOME/.direnvrc\" ]; then\n" +
 	"  source_env \"~/.direnvrc\" >&2\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -378,6 +378,17 @@ rvm() {
   rvm "$@"
 }
 
+# Usage: use_nix [...]
+#
+# Load environment variables from `nix-shell`.
+# If you have a `default.nix` or `shell.nix` these will be
+# used by default, but you can also specify packages directly
+# (e.g `use nix -p ocaml`).
+#
+use_nix() {
+  direnv_load nix-shell --show-trace "$@" --run 'direnv dump'
+}
+
 ## Load the global ~/.direnvrc if present
 if [ -f "$HOME/.direnvrc" ]; then
   source_env "~/.direnvrc" >&2


### PR DESCRIPTION
This lets users easily add [`nix`](http://nixos.org/nix/) expressions to their direnv environment, either by explicitly specifying packages:

    use nix -p python3 ocaml

..or by relying on the default `nix-shell` behaviour when you have a `default.nix` or `shell.nix` in the current directory:

    use nix

(This all relies on `nix` being installed, of course).