### PR TITLE
Fix lintian spelling warning

### DIFF
--- a/man/direnv.1
+++ b/man/direnv.1
@@ -9,7 +9,7 @@ direnv \- unclutter your .profile
 .PP
 \fB\fCdirenv\fR is an environment variable manager for your shell. It knows how to
 hook into bash, zsh and fish shell to load or unload environment variables
-depending on your current directory. This allows to have project\-specific
+depending on your current directory. This allows you to have project\-specific
 environment variables and not clutter the "~/.profile" file.
 .PP
 Before each prompt it checks for the existence of an ".envrc" file in the

--- a/man/direnv.1.md
+++ b/man/direnv.1.md
@@ -16,7 +16,7 @@ DESCRIPTION
 
 `direnv` is an environment variable manager for your shell. It knows how to
 hook into bash, zsh and fish shell to load or unload environment variables
-depending on your current directory. This allows to have project-specific
+depending on your current directory. This allows you to have project-specific
 environment variables and not clutter the "~/.profile" file.
 
 Before each prompt it checks for the existence of an ".envrc" file in the


### PR DESCRIPTION
Nitpick fix: lintian threw this warning when building the direnv package for debian.