### PR TITLE
Eliminate syntax ambiguity in zsh hooking script

### DIFF
--- a/shell_zsh.go
+++ b/shell_zsh.go
@@ -9,8 +9,8 @@ const ZSH_HOOK = `
 _direnv_hook() {
   eval "$(direnv export zsh)";
 }
-typeset -ag precmd_functions
-if [[ -z $precmd_functions[(r)_direnv_hook] ]]; then
+typeset -ag precmd_functions;
+if [[ -z ${precmd_functions[(r)_direnv_hook]} ]]; then
   precmd_functions+=_direnv_hook;
 fi
 `


### PR DESCRIPTION
Hi all,

After installed direnv 2.7.0 through Homebrew, I added `eval $(direnv hook zsh)` to my `.zshrc`, but the hook didn't work. And there are my findings.

The following element existence checking expresion:

    $precmd_functions[(r)_direnv_hook]
will be treated as following by ZSH interpreter:

    ${precmd_functions}[(r)_direnv_hook]

hence:

    [[ -z $precmd_functions[(r)_direnv_hook] ]] == [[ -z "[(r)_direnv_hook]" ]] == false

That's why this change is made. With this patch, `eval $(direnv hook zsh)` works perfectly in my shell (ZSH v5.0.5). Anyways, I have to say thanks to you to create such an awesome tool for us!

- Raphanus