### PR TITLE
Add `use node` directive to stdlib

### DIFF
--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -167,6 +167,26 @@ Example:
 * `rvm` ...:
     Should work just like in the shell if you have rvm installed.
 
+* `use node`:
+    Loads NodeJS version from a `.node-version` or `.nvmrc` file.
+
+Example (.envrc):
+
+    set -e
+    use node
+
+Example (.node-version):
+
+    4.2.2
+
+* `use node` version:
+    Loads specified NodeJS version.
+
+Example (.envrc):
+
+    set -e
+    use node 4.2.2
+
 COPYRIGHT
 ---------
 

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -389,6 +389,65 @@ rvm() {
   rvm "$@"
 }
 
+# Usage: use node
+# Loads NodeJS version from a `.node-version` or `.nvmrc` file.
+#
+# Usage: use node <version>
+# Loads specified NodeJS version.
+#
+# Environment Variables:
+#
+# - $NODE_VERSIONS (required)
+#   You must specify a path to your installed NodeJS versions via the `$NODE_VERSIONS` variable.
+#
+# - $NODE_VERSION_PREFIX (optional) [default="node-v"]
+#   Overrides the default version prefix.
+
+use_node() {
+  local VERSION=$1
+  local VIA=""
+  local COLOR_NORMAL=`tput sgr0`
+  local COLOR_ERROR="\e[0;31m"
+
+  if [[ -z $NODE_VERSIONS ]] || [[ ! -d $NODE_VERSIONS ]]; then
+    printf "${COLOR_ERROR}You must specify a \$NODE_VERSIONS environment variable and the directory specified must exist!${COLOR_NORMAL}" >&2
+    sleep 4
+    exit 1
+  fi
+
+  if [[ -z $VERSION ]] && [[ -f .nvmrc ]]; then
+    VERSION=$(cat .nvmrc)
+    VIA=".nvmrc"
+  fi
+
+  if [[ -z $VERSION ]] && [[ -f .node-version ]]; then
+    VERSION=$(cat .node-version)
+    VIA=".node-version"
+  fi
+
+  if [[ -z $VERSION ]]; then
+    printf "${COLOR_ERROR}I do not know which NodeJS version to load because one has not been specified!${COLOR_NORMAL}" >&2
+    sleep 4
+    exit 1
+  fi
+
+  local NODE_PREFIX=$NODE_VERSIONS/${NODE_VERSION_PREFIX:-"node-v"}$VERSION
+
+  if [[ ! -d $NODE_PREFIX ]]; then
+    printf "${COLOR_ERROR}Unable to find NodeJS version (%s) in (%s)!${COLOR_NORMAL}" $VERSION $NODE_VERSIONS >&2
+    sleep 4
+    exit 1
+  fi
+
+  if [[ -z $VIA ]]; then
+    echo "Loading NodeJS $VERSION from $NODE_PREFIX" >&1
+  else
+    echo "Loading NodeJS $VERSION via $VIA from $NODE_PREFIX" >&1
+  fi
+
+  load_prefix $NODE_PREFIX
+}
+
 # Usage: use_nix [...]
 #
 # Load environment variables from `nix-shell`.

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -457,8 +457,8 @@ use_node() {
 
   load_prefix $node_prefix
 
-  if [[ -z $(command -v node) ]]; then
-    log_error "Unable to load NodeJS version ($version)!"
+  if ! has node; then
+    log_error "Unable to load NodeJS binary (node) for version ($version) in ($NODE_VERSIONS)!"
     exit 1
   fi
 

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -430,7 +430,7 @@ use_node() {
 
   if [[ -z $NODE_VERSIONS ]] || [[ ! -d $NODE_VERSIONS ]]; then
     log_error "You must specify a \$NODE_VERSIONS environment variable and the directory specified must exist!"
-    exit 1
+    return 1
   fi
 
   if [[ -z $version ]] && [[ -f .nvmrc ]]; then
@@ -445,19 +445,19 @@ use_node() {
 
   if [[ -z $version ]]; then
     log_error "I do not know which NodeJS version to load because one has not been specified!"
-    exit 1
+    return 1
   fi
 
   local node_prefix=$NODE_VERSIONS/${NODE_VERSION_PREFIX:-"node-v"}$version
 
   if [[ ! -d $node_prefix ]]; then
     log_error "Unable to find NodeJS version ($version) in ($NODE_VERSIONS)!"
-    exit 1
+    return 1
   fi
 
   if [[ ! -x $node_prefix/bin/node ]]; then
     log_error "Unable to load NodeJS binary (node) for version ($version) in ($NODE_VERSIONS)!"
-    exit 1
+    return 1
   fi
 
   load_prefix $node_prefix

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -455,12 +455,12 @@ use_node() {
     exit 1
   fi
 
-  load_prefix $node_prefix
-
-  if ! has node; then
+  if [[ ! -x $node_prefix/bin/node ]]; then
     log_error "Unable to load NodeJS binary (node) for version ($version) in ($NODE_VERSIONS)!"
     exit 1
   fi
+
+  load_prefix $node_prefix
 
   if [[ -z $via ]]; then
     log_status "Successfully loaded NodeJS $(node --version), from prefix ($node_prefix)"


### PR DESCRIPTION
- `use node` Loads NodeJS version from a `.node-version` or `.nvmrc` file.
- `use node <version>` Loads specified NodeJS version.
- requires environment variable $NODE_VERSIONS
- optional environment variable $NODE_VERSION_PREFIX