### PR TITLE
Add fuzzy matching to `use node` stdlib function

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -217,6 +217,10 @@ Should work just like in the shell if you have rvm installed.
 .IP \(bu 2
 \fB\fCuse node\fR:
 Loads NodeJS version from a \fB\fC\&.node\-version\fR or \fB\fC\&.nvmrc\fR file.
+.PP
+If you specify a partial NodeJS version (i.e. \fB\fC4.2\fR), a fuzzy
+match is performed and the highest matching version installed
+is selected.
 .RE
 .PP
 Example (.envrc):
@@ -232,7 +236,7 @@ Example (.node\-version):
 .PP
 .RS
 .nf
-4.2.2
+4.2
 .fi
 .RE
 .RS

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -170,6 +170,10 @@ Example:
 * `use node`:
     Loads NodeJS version from a `.node-version` or `.nvmrc` file.
 
+    If you specify a partial NodeJS version (i.e. `4.2`), a fuzzy
+    match is performed and the highest matching version installed
+    is selected.
+
 Example (.envrc):
 
     set -e
@@ -177,7 +181,7 @@ Example (.envrc):
 
 Example (.node-version):
 
-    4.2.2
+    4.2
 
 * `use node` version:
     Loads specified NodeJS version.

--- a/stdlib.go
+++ b/stdlib.go
@@ -418,6 +418,9 @@ const STDLIB = "#!bash\n" +
 	"# Usage: use node <version>\n" +
 	"# Loads specified NodeJS version.\n" +
 	"#\n" +
+	"# If you specify a partial NodeJS version (i.e. `4.2`), a fuzzy match\n" +
+	"# is performed and the highest matching version installed is selected.\n" +
+	"#\n" +
 	"# Environment Variables:\n" +
 	"#\n" +
 	"# - $NODE_VERSIONS (required)\n" +
@@ -450,7 +453,8 @@ const STDLIB = "#!bash\n" +
 	"    return 1\n" +
 	"  fi\n" +
 	"\n" +
-	"  local node_prefix=$NODE_VERSIONS/${NODE_VERSION_PREFIX:-\"node-v\"}$version\n" +
+	"  local node_wanted=${NODE_VERSION_PREFIX:-\"node-v\"}$version\n" +
+	"  local node_prefix=$(find $NODE_VERSIONS -maxdepth 1 -mindepth 1 -type d -name \"$node_wanted*\" | sort -r -t . -k 1,1n -k 2,2n -k 3,3n | head -1)\n" +
 	"\n" +
 	"  if [[ ! -d $node_prefix ]]; then\n" +
 	"    log_error \"Unable to find NodeJS version ($version) in ($NODE_VERSIONS)!\"\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -416,6 +416,9 @@ rvm() {
 # Usage: use node <version>
 # Loads specified NodeJS version.
 #
+# If you specify a partial NodeJS version (i.e. `4.2`), a fuzzy match
+# is performed and the highest matching version installed is selected.
+#
 # Environment Variables:
 #
 # - $NODE_VERSIONS (required)
@@ -448,7 +451,8 @@ use_node() {
     return 1
   fi
 
-  local node_prefix=$NODE_VERSIONS/${NODE_VERSION_PREFIX:-"node-v"}$version
+  local node_wanted=${NODE_VERSION_PREFIX:-"node-v"}$version
+  local node_prefix=$(find $NODE_VERSIONS -maxdepth 1 -mindepth 1 -type d -name "$node_wanted*" | sort -r -t . -k 1,1n -k 2,2n -k 3,3n | head -1)
 
   if [[ ! -d $node_prefix ]]; then
     log_error "Unable to find NodeJS version ($version) in ($NODE_VERSIONS)!"


### PR DESCRIPTION
If you specify a partial NodeJS version (i.e. `4.2`), a fuzzy match is performed and the highest matching version installed is selected.