### PR TITLE
Add layout for projects using the gb build tool for Go

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -289,6 +289,20 @@ layout_go() {
   PATH_add bin
 }
 
+# Usage: layout gb
+#
+# Sets up environment for a Go project using the alternative gb build tool. In
+# addition to project executables on PATH, this includes an exclusive, project-
+# local GOPATH which enables many tools like gocode and oracle to "just work".
+#
+# http://getgb.io/
+#
+layout_gb() {
+  export GOPATH="$PWD/vendor:$PWD"
+  PATH_add "$PWD/vendor/bin"
+  PATH_add bin
+}
+
 # Usage: layout node
 #
 # Adds "$PWD/node_modules/.bin" to the PATH environment variable.


### PR DESCRIPTION
Hi,

Thanks for making direnv, it's quite handy!

I've been using [the gb build tool][1] for Go on private application projects, and I keep adding this setup to my `.envrc`s. It might be slightly controversial but since it's a small thing I thought I'd submit and see if there is interest.

The reason it might be slightly controversial is that `gb` doesn't actually use `GOPATH` at all—it's included here because [setting it facilitates use of common Go tools and their integration in editors][2]. Without direnv, teammates got tool integration working with vim-go, GoSublime, etc. by setting `GOPATH` (and possibly `PATH`) in project-local config like localvimrc or Sublime project-specific settings. After standardizing on using direnv, everyone simply starts their editor from their shell and things just work without extra editor-specific setup.

Unlike the `layout_go` already in direnv, this does not *extend* a global shared `GOPATH` with the local project directory, `gb`'s ideology is that the project's local `src` and `vendor` directories comprise everything needed to build the project, so tools shouldn't be analyzing any source or library archives outside of the project.

`$PWD/vendor/bin` is added to `PATH` for the sake of build dependencies that may install executable tools, for example the [Ginkgo BDD testing framework][3] includes a `ginkgo` test runner executable.

To be clear, intended usage is that you already have the typical Go development setup of a globally shared `GOPATH` configured in your shell environment by default, and `$GOPATH/bin` added to your path. This way you don't need to install copies of `gocode`, `godoc`, etc. in `vendor` of every project, the global ones installed with `go get` outside of a `gb` project will still be on your path and work when using `layout gb`. It should work fine if you *do* `go get` some of the tools while using the layout, it just might be slightly confusing that they get installed to `$PWD/vendor`, which is another caveat to consider.

[1]: http://getgb.io/
[2]: https://github.com/constabulary/gb/issues/42
[3]: http://onsi.github.io/ginkgo/