### PR TITLE
README.md: Caveat that .envrc must be valid bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ environment variables and not clutter the "~/.profile" file.
 
 Before each prompt it checks for the existence of an ".envrc" file in the
 current and parent directories. If the file exists (and authorized), it is
-loaded into a bash sub-shell and all exported variables are then captured by
+loaded into a **bash** sub-shell and all exported variables are then captured by
 direnv and then made available the current shell.
 
 Because direnv is compiled into a single static executable it is fast enough
@@ -103,6 +103,14 @@ eval `direnv hook tcsh`
 
 In some target folder, create an ".envrc" file and add some export(1)
 directives in it.
+
+Note that the contents of the `.envrc` file must be valid bash syntax,
+despite what shell you may be using.
+This is because direnv always executes the `.envrc` with bash (a sort of
+lowest common denominator of UNIX shells) so that direnv can work across shells.
+If you try to use some syntax that doesn't work in bash (like zsh's
+nested expansions), you will [run into
+trouble](https://github.com/direnv/direnv/issues/199).
 
 On the next prompt you will notice that direnv complains about the ".envrc"
 being blocked. This is the security mechanism to avoid loading new files


### PR DESCRIPTION
This was something that I overlooked which lead to me having [an issue](https://github.com/direnv/direnv/issues/199).

So I tried to add something to the `README.md` to try to make it clearer that the `.envrc` must use valid bash syntax.

https://github.com/msabramo/direnv/blob/README_add_caveat_that_envrc_must_be_valid_bash_syntax/README.md

Fixes: GH-199