### PR TITLE
Correct install instructions for zsh, bash

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -91,14 +91,14 @@ Bash
 
 ::
 
-    $ echo 'eval "direnv hook bash"' >> ~/.bashrc
+    $ echo 'eval $("direnv hook bash)"' >> ~/.bashrc && source ~/.bashrc
 
 Zsh
 ^^^
 
 ::
 
-    $ echo 'eval "direnv hook zsh"' >> ~/.zshrc
+    $ echo 'eval "$(direnv hook zsh)"' >> ~/.zshrc && source ~/.zshrc
 
 Fish shell
 ^^^^^^^^^^


### PR DESCRIPTION
Update bash and zsh entries according to: https://github.com/direnv/direnv#setup

(previously, the direnv hook was being printed to stdout when i sourced my profile, rather than being evaluated)

Other shells might need editing, but I only primarily use zsh..

Also, immediately source the profile.. is that too cheeky?