### PR TITLE
Export JSON

### DIFF
--- a/cmd_hook.go
+++ b/cmd_hook.go
@@ -21,7 +21,12 @@ var CmdHook = &Cmd{
 			return fmt.Errorf("Unknown target shell '%s'", target)
 		}
 
-		fmt.Println(shell.Hook())
+		h, err := shell.Hook()
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(h)
 
 		return
 	},

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -40,7 +40,10 @@ func watchCommand(env Env, args []string) (err error) {
 
 	watches.Update(path)
 
-	fmt.Printf(shell.Export(DIRENV_WATCHES, watches.Marshal()))
+	e := make(ShellExport)
+	e.Add(DIRENV_WATCHES, watches.Marshal())
+
+	fmt.Printf(shell.Export(e))
 
 	return
 }

--- a/env.go
+++ b/env.go
@@ -58,13 +58,13 @@ func (env Env) ToGoEnv() []string {
 }
 
 func (env Env) ToShell(shell Shell) string {
-	str := ""
+	e := make(ShellExport)
 
 	for key, value := range env {
-		str += shell.Export(key, value)
+		e.Add(key, value)
 	}
 
-	return str
+	return shell.Export(e)
 }
 
 func (env Env) Serialize() string {

--- a/env_diff.go
+++ b/env_diff.go
@@ -71,20 +71,20 @@ func (self *EnvDiff) Any() bool {
 }
 
 func (self *EnvDiff) ToShell(shell Shell) string {
-	str := ""
+	e := make(ShellExport)
 
 	for key := range self.Prev {
 		_, ok := self.Next[key]
 		if !ok {
-			str += shell.Unset(key)
+			e.Remove(key)
 		}
 	}
 
 	for key, value := range self.Next {
-		str += shell.Export(key, value)
+		e.Add(key, value)
 	}
 
-	return str
+	return shell.Export(e)
 }
 
 func (self *EnvDiff) Patch(env Env) (newEnv Env) {

--- a/shell.go
+++ b/shell.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"path/filepath"
 )
 
@@ -9,9 +8,19 @@ import (
  * Shells
  */
 type Shell interface {
-	Hook() string
-	Export(key, value string) string
-	Unset(key string) string
+	Hook() (string, error)
+	Export(e ShellExport) string
+}
+
+// Used to describe what to generate for the shell
+type ShellExport map[string]*string
+
+func (e ShellExport) Add(key, value string) {
+	e[key] = &value
+}
+
+func (e ShellExport) Remove(key string) {
+	e[key] = nil
 }
 
 func DetectShell(target string) Shell {
@@ -35,124 +44,4 @@ func DetectShell(target string) Shell {
 	}
 
 	return nil
-}
-
-/*
- * Escaping
- */
-
-const (
-	ACK           = 6
-	TAB           = 9
-	LF            = 10
-	CR            = 13
-	US            = 31
-	SPACE         = 32
-	AMPERSTAND    = 38
-	SINGLE_QUOTE  = 39
-	PLUS          = 43
-	NINE          = 57
-	QUESTION      = 63
-	LOWERCASE_Z   = 90
-	OPEN_BRACKET  = 91
-	BACKSLASH     = 92
-	UNDERSCORE    = 95
-	CLOSE_BRACKET = 93
-	BACKTICK      = 96
-	TILDA         = 126
-	DEL           = 127
-)
-
-// https://github.com/solidsnack/shell-escape/blob/master/Text/ShellEscape/Bash.hs
-/*
-A Bash escaped string. The strings are wrapped in @$\'...\'@ if any
-bytes within them must be escaped; otherwise, they are left as is.
-Newlines and other control characters are represented as ANSI escape
-sequences. High bytes are represented as hex codes. Thus Bash escaped
-strings will always fit on one line and never contain non-ASCII bytes.
-*/
-func ShellEscape(str string) string {
-	if str == "" {
-		return "''"
-	}
-	in := []byte(str)
-	out := ""
-	i := 0
-	l := len(in)
-	escape := false
-
-	hex := func(char byte) {
-		escape = true
-		out += fmt.Sprintf("\\x%02x", char)
-	}
-
-	backslash := func(char byte) {
-		escape = true
-		out += string([]byte{BACKSLASH, char})
-	}
-
-	escaped := func(str string) {
-		escape = true
-		out += str
-	}
-
-	quoted := func(char byte) {
-		escape = true
-		out += string([]byte{char})
-	}
-
-	literal := func(char byte) {
-		out += string([]byte{char})
-	}
-
-	for i < l {
-		char := in[i]
-		switch {
-		case char == TAB:
-			escaped(`\t`)
-		case char == LF:
-			escaped(`\n`)
-		case char == CR:
-			escaped(`\r`)
-		case char <= US:
-			hex(char)
-		case char <= AMPERSTAND:
-			quoted(char)
-		case char == SINGLE_QUOTE:
-			backslash(char)
-		case char <= PLUS:
-			quoted(char)
-		case char <= NINE:
-			literal(char)
-		case char <= QUESTION:
-			quoted(char)
-		case char <= LOWERCASE_Z:
-			literal(char)
-		case char == OPEN_BRACKET:
-			quoted(char)
-		case char == BACKSLASH:
-			backslash(char)
-		case char <= CLOSE_BRACKET:
-			quoted(char)
-		case char == UNDERSCORE:
-			literal(char)
-		case char <= BACKTICK:
-			quoted(char)
-		case char <= LOWERCASE_Z:
-			literal(char)
-		case char <= TILDA:
-			quoted(char)
-		case char == DEL:
-			hex(char)
-		default:
-			hex(char)
-		}
-		i += 1
-	}
-
-	if escape {
-		out = "$'" + out + "'"
-	}
-
-	return out
 }

--- a/shell.go
+++ b/shell.go
@@ -41,6 +41,8 @@ func DetectShell(target string) Shell {
 		return VIM
 	case "tcsh":
 		return TCSH
+	case "json":
+		return JSON
 	}
 
 	return nil

--- a/shell_bash.go
+++ b/shell_bash.go
@@ -1,5 +1,7 @@
 package main
 
+import "fmt"
+
 type bash int
 
 var BASH bash
@@ -15,18 +17,149 @@ if ! [[ "$PROMPT_COMMAND" =~ _direnv_hook ]]; then
 fi
 `
 
-func (b bash) Hook() string {
-	return BASH_HOOK
+func (b bash) Hook() (string, error) {
+	return BASH_HOOK, nil
 }
 
-func (b bash) Escape(str string) string {
-	return ShellEscape(str)
+func (b bash) Export(e ShellExport) (out string) {
+	for key, value := range e {
+		if value == nil {
+			out += b.unset(key)
+		} else {
+			out += b.export(key, *value)
+		}
+	}
+	return out
 }
 
-func (b bash) Export(key, value string) string {
-	return "export " + b.Escape(key) + "=" + b.Escape(value) + ";"
+func (b bash) export(key, value string) string {
+	return "export " + b.escape(key) + "=" + b.escape(value) + ";"
 }
 
-func (b bash) Unset(key string) string {
-	return "unset " + b.Escape(key) + ";"
+func (b bash) unset(key string) string {
+	return "unset " + b.escape(key) + ";"
+}
+
+func (b bash) escape(str string) string {
+	return BashEscape(str)
+}
+
+/*
+ * Escaping
+ */
+
+const (
+	ACK           = 6
+	TAB           = 9
+	LF            = 10
+	CR            = 13
+	US            = 31
+	SPACE         = 32
+	AMPERSTAND    = 38
+	SINGLE_QUOTE  = 39
+	PLUS          = 43
+	NINE          = 57
+	QUESTION      = 63
+	LOWERCASE_Z   = 90
+	OPEN_BRACKET  = 91
+	BACKSLASH     = 92
+	UNDERSCORE    = 95
+	CLOSE_BRACKET = 93
+	BACKTICK      = 96
+	TILDA         = 126
+	DEL           = 127
+)
+
+// https://github.com/solidsnack/shell-escape/blob/master/Text/ShellEscape/Bash.hs
+/*
+A Bash escaped string. The strings are wrapped in @$\'...\'@ if any
+bytes within them must be escaped; otherwise, they are left as is.
+Newlines and other control characters are represented as ANSI escape
+sequences. High bytes are represented as hex codes. Thus Bash escaped
+strings will always fit on one line and never contain non-ASCII bytes.
+*/
+func BashEscape(str string) string {
+	if str == "" {
+		return "''"
+	}
+	in := []byte(str)
+	out := ""
+	i := 0
+	l := len(in)
+	escape := false
+
+	hex := func(char byte) {
+		escape = true
+		out += fmt.Sprintf("\\x%02x", char)
+	}
+
+	backslash := func(char byte) {
+		escape = true
+		out += string([]byte{BACKSLASH, char})
+	}
+
+	escaped := func(str string) {
+		escape = true
+		out += str
+	}
+
+	quoted := func(char byte) {
+		escape = true
+		out += string([]byte{char})
+	}
+
+	literal := func(char byte) {
+		out += string([]byte{char})
+	}
+
+	for i < l {
+		char := in[i]
+		switch {
+		case char == TAB:
+			escaped(`\t`)
+		case char == LF:
+			escaped(`\n`)
+		case char == CR:
+			escaped(`\r`)
+		case char <= US:
+			hex(char)
+		case char <= AMPERSTAND:
+			quoted(char)
+		case char == SINGLE_QUOTE:
+			backslash(char)
+		case char <= PLUS:
+			quoted(char)
+		case char <= NINE:
+			literal(char)
+		case char <= QUESTION:
+			quoted(char)
+		case char <= LOWERCASE_Z:
+			literal(char)
+		case char == OPEN_BRACKET:
+			quoted(char)
+		case char == BACKSLASH:
+			backslash(char)
+		case char <= CLOSE_BRACKET:
+			quoted(char)
+		case char == UNDERSCORE:
+			literal(char)
+		case char <= BACKTICK:
+			quoted(char)
+		case char <= LOWERCASE_Z:
+			literal(char)
+		case char <= TILDA:
+			quoted(char)
+		case char == DEL:
+			hex(char)
+		default:
+			hex(char)
+		}
+		i += 1
+	}
+
+	if escape {
+		out = "$'" + out + "'"
+	}
+
+	return out
 }

--- a/shell_json.go
+++ b/shell_json.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type jsonShell int
+
+var JSON jsonShell
+
+func (s jsonShell) Hook() (string, error) {
+	return "", errors.New("this feature is not supported")
+}
+
+func (s jsonShell) Export(e ShellExport) string {
+	out, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		// Should never happen
+		panic(err)
+	}
+	return string(out)
+}

--- a/shell_test.go
+++ b/shell_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 )
 
-func TestShellEscape(t *testing.T) {
-	assertEqual(t, `''`, ShellEscape(""))
-	assertEqual(t, `$'escape\'quote'`, ShellEscape("escape'quote"))
-	assertEqual(t, `$'foo\r\n\tbar'`, ShellEscape("foo\r\n\tbar"))
-	assertEqual(t, `$'foo bar'`, ShellEscape("foo bar"))
-	assertEqual(t, `$'\xc3\xa9'`, ShellEscape("é"))
+func TestBashEscape(t *testing.T) {
+	assertEqual(t, `''`, BashEscape(""))
+	assertEqual(t, `$'escape\'quote'`, BashEscape("escape'quote"))
+	assertEqual(t, `$'foo\r\n\tbar'`, BashEscape("foo\r\n\tbar"))
+	assertEqual(t, `$'foo bar'`, BashEscape("foo bar"))
+	assertEqual(t, `$'\xc3\xa9'`, BashEscape("é"))
 }
 
 func TestShellDetection(t *testing.T) {

--- a/shell_vim.go
+++ b/shell_vim.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"os"
+	"errors"
 	"strings"
 )
 
@@ -9,26 +9,35 @@ type vim int
 
 var VIM vim
 
-func (x vim) Hook() string {
-	log_error("this feature is not supported. Install the direnv.vim plugin instead.")
-	os.Exit(1)
-	return ""
+func (x vim) Hook() (string, error) {
+	return "", errors.New("this feature is not supported. Install the direnv.vim plugin instead.")
+}
+
+func (x vim) Export(e ShellExport) (out string) {
+	for key, value := range e {
+		if value == nil {
+			out += x.unset(key)
+		} else {
+			out += x.export(key, *value)
+		}
+	}
+	return out
+}
+
+func (x vim) export(key, value string) string {
+	return "let $" + x.escapeKey(key) + " = " + x.escapeValue(value) + "\n"
+}
+
+func (x vim) unset(key string) string {
+	return "let $" + x.escapeKey(key) + " = ''\n"
 }
 
 // TODO: support keys with special chars or fail
-func (x vim) EscapeKey(str string) string {
+func (x vim) escapeKey(str string) string {
 	return str
 }
 
 // TODO: Make sure this escaping is valid
-func (x vim) EscapeValue(str string) string {
+func (x vim) escapeValue(str string) string {
 	return "'" + strings.Replace(str, "'", "''", -1) + "'"
-}
-
-func (x vim) Export(key, value string) string {
-	return "let $" + x.EscapeKey(key) + " = " + x.EscapeValue(value) + "\n"
-}
-
-func (x vim) Unset(key string) string {
-	return "let $" + x.EscapeKey(key) + " = ''\n"
 }

--- a/shell_zsh.go
+++ b/shell_zsh.go
@@ -15,18 +15,29 @@ if [[ -z ${precmd_functions[(r)_direnv_hook]} ]]; then
 fi
 `
 
-func (z zsh) Hook() string {
-	return ZSH_HOOK
+func (z zsh) Hook() (string, error) {
+	return ZSH_HOOK, nil
 }
 
-func (z zsh) Escape(str string) string {
-	return ShellEscape(str)
+func (z zsh) Export(e ShellExport) (out string) {
+	for key, value := range e {
+		if value == nil {
+			out += z.unset(key)
+		} else {
+			out += z.export(key, *value)
+		}
+	}
+	return out
 }
 
-func (z zsh) Export(key, value string) string {
-	return "export " + z.Escape(key) + "=" + z.Escape(value) + ";"
+func (z zsh) export(key, value string) string {
+	return "export " + z.escape(key) + "=" + z.escape(value) + ";"
 }
 
-func (z zsh) Unset(key string) string {
-	return "unset " + z.Escape(key) + ";"
+func (z zsh) unset(key string) string {
+	return "unset " + z.escape(key) + ";"
+}
+
+func (z zsh) escape(str string) string {
+	return BashEscape(str)
 }


### PR DESCRIPTION
A new export format that makes it easier to integrate direnv with IDEs.

The IDE has to call `direnv export json`.
If the exit status > 0 display the output and abort.
Parse the JSON, the format is `{"key": value}` where the value is either a string or null. If the string is null unset the env, otherwise set it.