### PR TITLE
Build-time bash path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,20 @@ DESTDIR ?= /usr/local
 MAN_MD = $(wildcard man/*.md)
 ROFFS = $(MAN_MD:.md=)
 
+GO_LDFLAGS =
+
 ifeq ($(shell uname), Darwin)
 	# Fixes DYLD_INSERT_LIBRARIES issues
 	# See https://github.com/direnv/direnv/issues/194
-	GO_FLAGS += -ldflags -linkmode=external
+	GO_LDFLAGS += -linkmode=external
+endif
+
+ifdef BASH_PATH
+	GO_LDFLAGS += -X main.bashPath=$(BASH_PATH)
+endif
+
+ifdef GO_LDFLAGS
+	GO_FLAGS += -ldflags '$(GO_LDFLAGS)'
 endif
 
 .PHONY: all man html test install dist

--- a/config.go
+++ b/config.go
@@ -45,7 +45,9 @@ func LoadConfig(env Env) (config *Config, err error) {
 
 	config.BashPath = env[DIRENV_BASH]
 	if config.BashPath == "" {
-		if config.BashPath, err = exec.LookPath("bash"); err != nil {
+		if bashPath != "" {
+			config.BashPath = bashPath
+		} else if config.BashPath, err = exec.LookPath("bash"); err != nil {
 			err = fmt.Errorf("Can't find bash: %q", err)
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,9 @@ import (
 	"os"
 )
 
+// Configured at compile time
+var bashPath string
+
 func main() {
 	var env = GetEnv()
 	var args = os.Args


### PR DESCRIPTION
This change allows to hard-code the bash path into direnv at compile
time. This avoiding a lookup on the $PATH on every evaluation of direnv.

To do this run `make BASH_PATH=$(readlink -f $(which bash))`.

There is no measurable difference on a SSD.

/cc @pwaller 

This is going to be useful in nix packaging to provide bash path as an immutable build dependency.