### PR TITLE
Permit empty NODE_VERSION_PREFIX variable

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -492,7 +492,7 @@ const STDLIB = "#!bash\n" +
 	"    return 1\n" +
 	"  fi\n" +
 	"\n" +
-	"  node_wanted=${NODE_VERSION_PREFIX:-\"node-v\"}$version\n" +
+	"  node_wanted=${NODE_VERSION_PREFIX-\"node-v\"}$version\n" +
 	"  node_prefix=$(find \"$NODE_VERSIONS\" -maxdepth 1 -mindepth 1 -type d -name \"$node_wanted*\" | sort -r -t . -k 1,1n -k 2,2n -k 3,3n | head -1)\n" +
 	"\n" +
 	"  if [[ ! -d $node_prefix ]]; then\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -490,7 +490,7 @@ use_node() {
     return 1
   fi
 
-  node_wanted=${NODE_VERSION_PREFIX:-"node-v"}$version
+  node_wanted=${NODE_VERSION_PREFIX-"node-v"}$version
   node_prefix=$(find "$NODE_VERSIONS" -maxdepth 1 -mindepth 1 -type d -name "$node_wanted*" | sort -r -t . -k 1,1n -k 2,2n -k 3,3n | head -1)
 
   if [[ ! -d $node_prefix ]]; then


### PR DESCRIPTION
I use [n](https://github.com/tj/n) (It's very famous node.js manager). It install node.js to non-prefixed directory.

```
% ls n/versions/node
0.10.36  0.12.12  4.3.2  5.7.1  6.2.0
```

direnv can change node.js search prefix via the `NODE_VERSION_PREFIX` variable, but can't accept  empty string. The PR is fixed it.