### PR TITLE
When MANPATH is empty, prepend to a default value in path_add

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -257,7 +257,10 @@ path_add() {
 
   if [[ -z $old_paths ]]; then
     if [[ $1 = MANPATH ]]; then
-      # If empty, prepend $dir to the default
+      # If MANPATH is empty, man still knows where to look.
+      # If MANPATH is not empty, man will only look in MANPATH.
+      # So if we set MANPATH=$dir, man will only look in $dir.
+      # Instead, prepend to `man -w` (which outputs man's default paths).
       old_paths="$dir:$(man -w)"
     else
       old_paths="$dir"

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -256,7 +256,12 @@ path_add() {
   dir=$(expand_path "$2")
 
   if [[ -z $old_paths ]]; then
-    old_paths="$dir"
+    if [[ $1 = MANPATH ]]; then
+      # If empty, prepend $dir to the default
+      old_paths="$dir:$(man -w)"
+    else
+      old_paths="$dir"
+    fi
   else
     old_paths="$dir:$old_paths"
   fi

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -256,20 +256,28 @@ path_add() {
   dir=$(expand_path "$2")
 
   if [[ -z $old_paths ]]; then
-    if [[ $1 = MANPATH ]]; then
-      # If MANPATH is empty, man still knows where to look.
-      # If MANPATH is not empty, man will only look in MANPATH.
-      # So if we set MANPATH=$dir, man will only look in $dir.
-      # Instead, prepend to `man -w` (which outputs man's default paths).
-      old_paths="$dir:$(man -w)"
-    else
-      old_paths="$dir"
-    fi
+    old_paths="$dir"
   else
     old_paths="$dir:$old_paths"
   fi
 
   export "$1=$old_paths"
+}
+
+# Usage: MANPATH_add <path>
+#
+# Prepends a path to the MANPATH environment variable while making sure that
+# `man` can still lookup the system manual pages.
+#
+# If MANPATH is not empty, man will only look in MANPATH.
+# So if we set MANPATH=$path, man will only look in $path.
+# Instead, prepend to `man -w` (which outputs man's default paths).
+#
+MANPATH_add() {
+  local old_paths="${!1}"
+  local dir
+  dir=$(expand_path "$2")
+  export "$1=$dir:${old_paths:-$(man -w)}"
 }
 
 # Usage: load_prefix <prefix_path>
@@ -298,11 +306,11 @@ path_add() {
 load_prefix() {
   local dir
   dir=$(expand_path "$1")
+  MANPATH_add "$dir/man"
+  MANPATH_add "$dir/share/man"
   path_add CPATH "$dir/include"
   path_add LD_LIBRARY_PATH "$dir/lib"
   path_add LIBRARY_PATH "$dir/lib"
-  path_add MANPATH "$dir/man"
-  path_add MANPATH "$dir/share/man"
   path_add PATH "$dir/bin"
   path_add PKG_CONFIG_PATH "$dir/lib/pkgconfig"
 }


### PR DESCRIPTION
If `$MANPATH` is empty, `man` still knows where to look.

If `$MANPATH` is not empty, `man` will only look in those paths.

Instead of setting `MANPATH=$dir` in `path_add`, prepend `$dir` to the default MANPATH-equivalent calculated with `man -w`.

For Darwin, see "SEARCH PATH FOR MANUAL PAGES" section of [`man man`](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/man.1.html).

For Linux, see [`man 5 manpath`](http://man7.org/linux/man-pages/man5/manpath.5.html).

Fixes #247.