### PR TITLE
Fix/252 node version sorting

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -525,6 +525,8 @@ use_node() {
     head -1
   )
 
+  node_prefix="$NODE_VERSIONS/${NODE_VERSION_PREFIX-"node-v"}$node_prefix"
+
   if [[ ! -d $node_prefix ]]; then
     log_error "Unable to find NodeJS version ($version) in ($NODE_VERSIONS)!"
     return 1

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -519,7 +519,7 @@ use_node() {
     while IFS= read -r line; do echo "${line#${NODE_VERSIONS%/}/${NODE_VERSION_PREFIX-"node-v"}}"; done |
 
     # Sort by version: split by "." then reverse numeric sort for each piece of the version string
-    sort -r -t . -k 1,1n -k 2,2n -k 3,3n |
+    sort -t . -k 1,1rn -k 2,2rn -k 3,3rn |
 
     # The first one is the highest
     head -1

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -510,7 +510,16 @@ use_node() {
   fi
 
   node_wanted=${NODE_VERSION_PREFIX-"node-v"}$version
-  node_prefix=$(find "$NODE_VERSIONS" -maxdepth 1 -mindepth 1 -type d -name "$node_wanted*" | sort -r -t . -k 1,1n -k 2,2n -k 3,3n | head -1)
+  node_prefix=$(
+    # Look for matching node versions in $NODE_VERSIONS path
+    find "$NODE_VERSIONS" -maxdepth 1 -mindepth 1 -type d -name "$node_wanted*" |
+
+    # Sort by version: split by "." then reverse numeric sort for each piece of the version string
+    sort -r -t . -k 1,1n -k 2,2n -k 3,3n |
+
+    # The first one is the highest
+    head -1
+  )
 
   if [[ ! -d $node_prefix ]]; then
     log_error "Unable to find NodeJS version ($version) in ($NODE_VERSIONS)!"

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -514,6 +514,10 @@ use_node() {
     # Look for matching node versions in $NODE_VERSIONS path
     find "$NODE_VERSIONS" -maxdepth 1 -mindepth 1 -type d -name "$node_wanted*" |
 
+    # Strip possible "/" suffix from $NODE_VERSIONS, then use that to
+    # Strip $NODE_VERSIONS/$NODE_VERSION_PREFIX prefix from line.
+    while IFS= read -r line; do echo "${line#${NODE_VERSIONS%/}/${NODE_VERSION_PREFIX-"node-v"}}"; done |
+
     # Sort by version: split by "." then reverse numeric sort for each piece of the version string
     sort -r -t . -k 1,1n -k 2,2n -k 3,3n |
 

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -486,6 +486,7 @@ rvm() {
 use_node() {
   local version=$1
   local via=""
+  local node_version_prefix=${NODE_VERSION_PREFIX:-node-v}
   local node_wanted
   local node_prefix
 
@@ -509,14 +510,14 @@ use_node() {
     return 1
   fi
 
-  node_wanted=${NODE_VERSION_PREFIX-"node-v"}$version
+  node_wanted=${node_version_prefix}${version}
   node_prefix=$(
     # Look for matching node versions in $NODE_VERSIONS path
     find "$NODE_VERSIONS" -maxdepth 1 -mindepth 1 -type d -name "$node_wanted*" |
 
     # Strip possible "/" suffix from $NODE_VERSIONS, then use that to
     # Strip $NODE_VERSIONS/$NODE_VERSION_PREFIX prefix from line.
-    while IFS= read -r line; do echo "${line#${NODE_VERSIONS%/}/${NODE_VERSION_PREFIX-"node-v"}}"; done |
+    while IFS= read -r line; do echo "${line#${NODE_VERSIONS%/}/${node_version_prefix}}"; done |
 
     # Sort by version: split by "." then reverse numeric sort for each piece of the version string
     sort -t . -k 1,1rn -k 2,2rn -k 3,3rn |
@@ -525,7 +526,7 @@ use_node() {
     head -1
   )
 
-  node_prefix="$NODE_VERSIONS/${NODE_VERSION_PREFIX-"node-v"}$node_prefix"
+  node_prefix="${NODE_VERSIONS}/${node_version_prefix}${node_prefix}"
 
   if [[ ! -d $node_prefix ]]; then
     log_error "Unable to find NodeJS version ($version) in ($NODE_VERSIONS)!"


### PR DESCRIPTION
As #252 points out, there are two problems with the sorting of node versions.
1. The path to the node versions may contain a `.`, which is the separator used by `sort`.
2. `sort`'s `-r` and `-k` flags don't combine as expected.

This PR:
1. Strips the path prefix from the strings to sort, and
2. Fixes the sorting by moving the reversal flag to each individual key's options.

It also splits the multi-pipe command into several lines for readability, but I don't know how portable that is.

Fixes #252