### PR TITLE
Typo in MANPATH_add always generates "PATH missing" error

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -279,8 +279,8 @@ path_add() {
 MANPATH_add() {
   local old_paths="${!1}"
   local dir
-  dir=$(expand_path "$2")
-  export "$1=$dir:${old_paths:-$(man -w)}"
+  dir=$(expand_path "$1")
+  export "MANPATH=$dir:${old_paths:-$(man -w)}"
 }
 
 # Usage: load_prefix <prefix_path>


### PR DESCRIPTION
PR #248 fixed some MANPATH issues, but it also introduced some copy/paste typos.

https://github.com/direnv/direnv/blob/v2.11.1/stdlib.sh#L270-L284

```
Usage: MANPATH_add <path>
...
dir=$(expand_path "$2")
```

There is no `$2`.

This PR switches to the correct parameters in `MANPATH_add()`.