### PR TITLE
stdlib: configurable direnv_layout_dir

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -598,7 +598,7 @@ const STDLIB = "#!bash\n" +
 	"\n" +
 	"## Load the global ~/.direnvrc if present\n" +
 	"if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/direnv/direnvrc ]]; then\n" +
-	"  source_env \"${XDG_CONFIG_HOME:-$HOME/.config}/direnv/direnvrc\" >&2\n" +
+	"  source \"${XDG_CONFIG_HOME:-$HOME/.config}/direnv/direnvrc\" >&2\n" +
 	"elif [[ -f $HOME/.direnvrc ]]; then\n" +
-	"  source_env \"$HOME/.direnvrc\" >&2\n" +
+	"  source \"$HOME/.direnvrc\" >&2\n" +
 	"fi\n"

--- a/stdlib.go
+++ b/stdlib.go
@@ -7,7 +7,9 @@ const STDLIB = "#!bash\n" +
 	"set -e\n" +
 	"direnv=\"%s\"\n" +
 	"\n" +
+	"# Config, change in the direnvrc\n" +
 	"DIRENV_LOG_FORMAT=\"${DIRENV_LOG_FORMAT-direnv: %%s}\"\n" +
+	"direnv_layout_dir=$PWD/.direnv\n" +
 	"\n" +
 	"# Usage: log_status [<message> ...]\n" +
 	"#\n" +
@@ -361,7 +363,7 @@ const STDLIB = "#!bash\n" +
 	"# See http://search.cpan.org/dist/local-lib/lib/local/lib.pm for more details\n" +
 	"#\n" +
 	"layout_perl() {\n" +
-	"  local libdir=$PWD/.direnv/perl5\n" +
+	"  local libdir=$direnv_layout_dir/perl5\n" +
 	"  export LOCAL_LIB_DIR=$libdir\n" +
 	"  export PERL_MB_OPT=\"--install_base '$libdir'\"\n" +
 	"  export PERL_MM_OPT=\"INSTALL_BASE=$libdir\"\n" +
@@ -373,7 +375,7 @@ const STDLIB = "#!bash\n" +
 	"# Usage: layout python <python_exe>\n" +
 	"#\n" +
 	"# Creates and loads a virtualenv environment under\n" +
-	"# \"$PWD/.direnv/python-$python_version\".\n" +
+	"# \"$direnv_layout_dir/python-$python_version\".\n" +
 	"# This forces the installation of any egg into the project's sub-folder.\n" +
 	"#\n" +
 	"# It's possible to specify the python executable if you want to use different\n" +
@@ -382,7 +384,7 @@ const STDLIB = "#!bash\n" +
 	"layout_python() {\n" +
 	"  local python=${1:-python}\n" +
 	"  [[ $# -gt 0 ]] && shift\n" +
-	"  local old_env=$PWD/.direnv/virtualenv\n" +
+	"  local old_env=$direnv_layout_dir/virtualenv\n" +
 	"  unset PYTHONHOME\n" +
 	"  if [[ -d $old_env && $python = python ]]; then\n" +
 	"    export VIRTUAL_ENV=$old_env\n" +
@@ -394,7 +396,7 @@ const STDLIB = "#!bash\n" +
 	"      return 1\n" +
 	"    fi\n" +
 	"\n" +
-	"    export VIRTUAL_ENV=$PWD/.direnv/python-$python_version\n" +
+	"    export VIRTUAL_ENV=$direnv_layout_dir/python-$python_version\n" +
 	"    if [[ ! -d $VIRTUAL_ENV ]]; then\n" +
 	"      virtualenv \"--python=$python\" \"$@\" \"$VIRTUAL_ENV\"\n" +
 	"    fi\n" +
@@ -420,20 +422,20 @@ const STDLIB = "#!bash\n" +
 	"\n" +
 	"# Usage: layout ruby\n" +
 	"#\n" +
-	"# Sets the GEM_HOME environment variable to \"$PWD/.direnv/ruby/RUBY_VERSION\".\n" +
+	"# Sets the GEM_HOME environment variable to \"$direnv_layout_dir/ruby/RUBY_VERSION\".\n" +
 	"# This forces the installation of any gems into the project's sub-folder.\n" +
 	"# If you're using bundler it will create wrapper programs that can be invoked\n" +
 	"# directly instead of using the $(bundle exec) prefix.\n" +
 	"#\n" +
 	"layout_ruby() {\n" +
 	"  if ruby -e \"exit Gem::VERSION > '2.2.0'\" 2>/dev/null; then\n" +
-	"    export GEM_HOME=$PWD/.direnv/ruby\n" +
+	"    export GEM_HOME=$direnv_layout_dir/ruby\n" +
 	"  else\n" +
 	"    local ruby_version\n" +
 	"    ruby_version=$(ruby -e\"puts (defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby') + '-' + RUBY_VERSION\")\n" +
-	"    export GEM_HOME=$PWD/.direnv/ruby-${ruby_version}\n" +
+	"    export GEM_HOME=$direnv_layout_dir/ruby-${ruby_version}\n" +
 	"  fi\n" +
-	"  export BUNDLE_BIN=$PWD/.direnv/bin\n" +
+	"  export BUNDLE_BIN=$direnv_layout_dir/bin\n" +
 	"\n" +
 	"  PATH_add \"$GEM_HOME/bin\"\n" +
 	"  PATH_add \"$BUNDLE_BIN\"\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -596,7 +596,7 @@ use_guix() {
 
 ## Load the global ~/.direnvrc if present
 if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/direnv/direnvrc ]]; then
-  source_env "${XDG_CONFIG_HOME:-$HOME/.config}/direnv/direnvrc" >&2
+  source "${XDG_CONFIG_HOME:-$HOME/.config}/direnv/direnvrc" >&2
 elif [[ -f $HOME/.direnvrc ]]; then
-  source_env "$HOME/.direnvrc" >&2
+  source "$HOME/.direnvrc" >&2
 fi

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -5,7 +5,9 @@
 set -e
 direnv="%s"
 
+# Config, change in the direnvrc
 DIRENV_LOG_FORMAT="${DIRENV_LOG_FORMAT-direnv: %%s}"
+direnv_layout_dir=$PWD/.direnv
 
 # Usage: log_status [<message> ...]
 #
@@ -359,7 +361,7 @@ layout_node() {
 # See http://search.cpan.org/dist/local-lib/lib/local/lib.pm for more details
 #
 layout_perl() {
-  local libdir=$PWD/.direnv/perl5
+  local libdir=$direnv_layout_dir/perl5
   export LOCAL_LIB_DIR=$libdir
   export PERL_MB_OPT="--install_base '$libdir'"
   export PERL_MM_OPT="INSTALL_BASE=$libdir"
@@ -371,7 +373,7 @@ layout_perl() {
 # Usage: layout python <python_exe>
 #
 # Creates and loads a virtualenv environment under
-# "$PWD/.direnv/python-$python_version".
+# "$direnv_layout_dir/python-$python_version".
 # This forces the installation of any egg into the project's sub-folder.
 #
 # It's possible to specify the python executable if you want to use different
@@ -380,7 +382,7 @@ layout_perl() {
 layout_python() {
   local python=${1:-python}
   [[ $# -gt 0 ]] && shift
-  local old_env=$PWD/.direnv/virtualenv
+  local old_env=$direnv_layout_dir/virtualenv
   unset PYTHONHOME
   if [[ -d $old_env && $python = python ]]; then
     export VIRTUAL_ENV=$old_env
@@ -392,7 +394,7 @@ layout_python() {
       return 1
     fi
 
-    export VIRTUAL_ENV=$PWD/.direnv/python-$python_version
+    export VIRTUAL_ENV=$direnv_layout_dir/python-$python_version
     if [[ ! -d $VIRTUAL_ENV ]]; then
       virtualenv "--python=$python" "$@" "$VIRTUAL_ENV"
     fi
@@ -418,20 +420,20 @@ layout_python3() {
 
 # Usage: layout ruby
 #
-# Sets the GEM_HOME environment variable to "$PWD/.direnv/ruby/RUBY_VERSION".
+# Sets the GEM_HOME environment variable to "$direnv_layout_dir/ruby/RUBY_VERSION".
 # This forces the installation of any gems into the project's sub-folder.
 # If you're using bundler it will create wrapper programs that can be invoked
 # directly instead of using the $(bundle exec) prefix.
 #
 layout_ruby() {
   if ruby -e "exit Gem::VERSION > '2.2.0'" 2>/dev/null; then
-    export GEM_HOME=$PWD/.direnv/ruby
+    export GEM_HOME=$direnv_layout_dir/ruby
   else
     local ruby_version
     ruby_version=$(ruby -e"puts (defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby') + '-' + RUBY_VERSION")
-    export GEM_HOME=$PWD/.direnv/ruby-${ruby_version}
+    export GEM_HOME=$direnv_layout_dir/ruby-${ruby_version}
   fi
-  export BUNDLE_BIN=$PWD/.direnv/bin
+  export BUNDLE_BIN=$direnv_layout_dir/bin
 
   PATH_add "$GEM_HOME/bin"
   PATH_add "$BUNDLE_BIN"


### PR DESCRIPTION
Introduce the `$direnv_layout_dir` variable to let the user select
out-of-folder layouts. The main purpose of making this configurable is
to allow the user to store the `.direnv` folder outside of the
project's directory. For example if it interracts badly with backups,
source control or the IDE.

The variable can be changed in the `.envrc` file or in the global
`~/.config/direnv/direnvrc` file. In that case on might want to hash the
project path like that:

```
: ${XDG_CACHE_HOME:=$HOME/.cache}
pwd_hash=$(echo -n $PWD | shasum | cut -d ' ' -f 1)
direnv_layout_dir=$XDG_CACHE_HOME/direnv/layouts/$pwd_hash
```