### PR TITLE
pwd: Don't use -P to remove symlinks

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -147,7 +147,7 @@ const STDLIB = "#!bash\n" +
 	"#\n" +
 	"find_up() {\n" +
 	"  (\n" +
-	"    cd \"$(pwd -P 2>/dev/null)\"\n" +
+	"    cd \"$(pwd 2>/dev/null)\"\n" +
 	"    while true; do\n" +
 	"      if [[ -f $1 ]]; then\n" +
 	"        echo \"$PWD/$1\"\n" +
@@ -176,7 +176,7 @@ const STDLIB = "#!bash\n" +
 	"  rcfile=$(user_rel_path \"$rcpath\")\n" +
 	"  watch_file \"$rcpath\"\n" +
 	"\n" +
-	"  pushd \"$(pwd -P 2>/dev/null)\" > /dev/null\n" +
+	"  pushd \"$(pwd 2>/dev/null)\" > /dev/null\n" +
 	"    pushd \"$(dirname \"$rcpath\")\" > /dev/null\n" +
 	"    if [[ -f ./$(basename \"$rcpath\") ]]; then\n" +
 	"      log_status \"loading $rcfile\"\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -145,7 +145,7 @@ user_rel_path() {
 #
 find_up() {
   (
-    cd "$(pwd -P 2>/dev/null)"
+    cd "$(pwd 2>/dev/null)"
     while true; do
       if [[ -f $1 ]]; then
         echo "$PWD/$1"
@@ -174,7 +174,7 @@ source_env() {
   rcfile=$(user_rel_path "$rcpath")
   watch_file "$rcpath"
 
-  pushd "$(pwd -P 2>/dev/null)" > /dev/null
+  pushd "$(pwd 2>/dev/null)" > /dev/null
     pushd "$(dirname "$rcpath")" > /dev/null
     if [[ -f ./$(basename "$rcpath") ]]; then
       log_status "loading $rcfile"


### PR DESCRIPTION
If you use -P you get the absolute "physical" path removing any
symlinks, however it is then used in a context where it is expecting a
relative path to find the .envrc file. As a result, it can often be
incorrect and cause `pushd` errors.

Fixes GH#294