### PR TITLE
use_nix: unset IN_NIX_SHELL

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -635,11 +635,13 @@ use_node() {
 # (e.g `use nix -p ocaml`).
 #
 use_nix() {
+  local orig_IN_NIX_SHELL="$IN_NIX_SHELL"
   direnv_load nix-shell --show-trace "$@" --run 'direnv dump'
   if [[ $# = 0 ]]; then
     watch_file default.nix
     watch_file shell.nix
   fi
+  IN_NIX_SHELL="$orig_IN_NIX_SHELL"
 }
 
 # Usage: use_guix [...]


### PR DESCRIPTION
nix-shell sets the environment variable IN_NIX_SHELL when evaluation happens
inside a shell. direnv picks up this variable and sets it outside
nix-shell. Subsequent evaluation can fail if IN_NIX_SHELL is set but we are not,
in fact, in nix-shell. Therefore, use_nix should restore the original value of
IN_NIX_SHELL after loading the environment.