### PR TITLE
Allow whitelisting specific .envrc paths.

### DIFF
--- a/cmd_allow.go
+++ b/cmd_allow.go
@@ -25,7 +25,7 @@ var CmdAllow = &Cmd{
 			return
 		}
 
-		rc := FindRC(rcPath, config.AllowDir())
+		rc := FindRC(rcPath, config.AllowDir(), config.WhitelistDir())
 		if rc == nil {
 			return fmt.Errorf(".envrc file not found")
 		}

--- a/cmd_edit.go
+++ b/cmd_edit.go
@@ -67,7 +67,7 @@ var CmdEdit = &Cmd{
 			return
 		}
 
-		foundRC = FindRC(rcPath, config.AllowDir())
+		foundRC = FindRC(rcPath, config.AllowDir(), config.WhitelistDir())
 		log_debug("foundRC: %#v", foundRC)
 		log_debug("times: %#v", times)
 		if times != nil {

--- a/cmd_exec.go
+++ b/cmd_exec.go
@@ -47,7 +47,7 @@ var CmdExec = &Cmd{
 			return
 		}
 
-		rc := FindRC(rcPath, config.AllowDir())
+		rc := FindRC(rcPath, config.AllowDir(), config.WhitelistDir())
 
 		// Restore pristine environment if needed
 		if backupDiff, err = config.EnvDiff(); err == nil {

--- a/cmd_unwhitelist.go
+++ b/cmd_unwhitelist.go
@@ -5,10 +5,10 @@ import (
 	"os"
 )
 
-// `direnv deny [PATH_TO_RC]`
-var CmdDeny = &Cmd{
-	Name: "deny",
-	Desc: "Revokes the authorization of a given .envrc",
+// `direnv unwhitelist [PATH_TO_RC]`
+var CmdUnWhitelist = &Cmd{
+	Name: "unwhitelist",
+	Desc: "Revokes the whitelisting of .envrc files at the given path",
 	Args: []string{"[PATH_TO_RC]"},
 	Fn: func(env Env, args []string) (err error) {
 		var rcPath string
@@ -30,6 +30,6 @@ var CmdDeny = &Cmd{
 		if rc == nil {
 			return fmt.Errorf(".envrc file not found")
 		}
-		return rc.Deny()
+		return rc.UnWhitelist()
 	},
 }

--- a/cmd_whitelist.go
+++ b/cmd_whitelist.go
@@ -5,15 +5,14 @@ import (
 	"os"
 )
 
-// `direnv deny [PATH_TO_RC]`
-var CmdDeny = &Cmd{
-	Name: "deny",
-	Desc: "Revokes the authorization of a given .envrc",
+// `direnv whitelist [PATH_TO_RC]`
+var CmdWhitelist = &Cmd{
+	Name: "whitelist",
+	Desc: "Permanently allows any .envrc that resides at the given path",
 	Args: []string{"[PATH_TO_RC]"},
 	Fn: func(env Env, args []string) (err error) {
 		var rcPath string
 		var config *Config
-
 		if len(args) > 1 {
 			rcPath = args[1]
 		} else {
@@ -30,6 +29,6 @@ var CmdDeny = &Cmd{
 		if rc == nil {
 			return fmt.Errorf(".envrc file not found")
 		}
-		return rc.Deny()
+		return rc.Whitelist()
 	},
 }

--- a/commands.go
+++ b/commands.go
@@ -35,8 +35,10 @@ func init() {
 		CmdReload,
 		CmdStatus,
 		CmdStdlib,
+		CmdUnWhitelist,
 		CmdVersion,
 		CmdWatch,
+		CmdWhitelist,
 		CmdCurrent,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -70,6 +70,10 @@ func (self *Config) AllowDir() string {
 	return filepath.Join(self.ConfDir, "allow")
 }
 
+func (self *Config) WhitelistDir() string {
+	return filepath.Join(self.ConfDir, "whitelist")
+}
+
 func (self *Config) LoadedRC() *RC {
 	if self.RCDir == "" {
 		log_debug("RCDir is blank - loadedRC is nil")
@@ -83,7 +87,7 @@ func (self *Config) LoadedRC() *RC {
 }
 
 func (self *Config) FindRC() *RC {
-	return FindRC(self.WorkDir, self.AllowDir())
+	return FindRC(self.WorkDir, self.AllowDir(), self.WhitelistDir())
 }
 
 func (self *Config) EnvDiff() (*EnvDiff, error) {


### PR DESCRIPTION
This is intended to cover the case where you may have frequently changing .envrc files whose source you trust (for example, a version-controlled envrc in a team environment). The whitelisting can be revoked, at which point the normal allow/deny operations resume effect.

This has been previously requested in https://github.com/direnv/direnv/issues/180. To answer questions on that issue, on my team we do commit .envrc files to automatically set developers up with project-specific configuration and local PATH overrides. It would be really nice to provide devs with a script that will whitelist all of the .envrc paths within our repo, so they don't need to allow, cd out, and cd back in every time they pull or rebase and a file has changed.

One thing to note is that I've chosen to whitelist the absolute path of the file for less ambiguity, although I'm honestly not sure whether that's more or less surprising behavior than whitelisting the path the user provides, symlinks or no.

I've tested this locally on my machine, but I honestly don't quite understand how the tests in this repository are set up so I haven't added automated ones. The logic is pretty simple, but if you'd like it to come with test coverage I can poke around some more.

Happy to discuss if this approach doesn't work for you!