### PR TITLE
fix support for go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 go:
-- 1.5.x
-- 1.6.x
-- 1.7.x
 - 1.8.x
+- 1.9.x
+- 1.10.x
 sudo: false
 script: make test
 branches:
@@ -34,4 +33,4 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    condition: $TRAVIS_GO_VERSION =~ ^1\.8\..*$
+    condition: $TRAVIS_GO_VERSION =~ ^1\.10\..*$

--- a/cmd_stdlib.go
+++ b/cmd_stdlib.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 )
 
 // `direnv stdlib`
@@ -14,7 +15,7 @@ var CmdStdlib = &Cmd{
 			return
 		}
 
-		fmt.Printf(STDLIB, config.SelfPath)
+		fmt.Println(strings.Replace(STDLIB, "$(which direnv)", config.SelfPath, 1))
 		return
 	},
 }

--- a/stdlib.go
+++ b/stdlib.go
@@ -5,10 +5,11 @@ const STDLIB = "#!bash\n" +
 	"# These are the commands available in an .envrc context\n" +
 	"#\n" +
 	"set -e\n" +
-	"direnv=\"%s\"\n" +
+	"# NOTE: don't touch the RHS, it gets replaced at runtime\n" +
+	"direnv=\"$(which direnv)\"\n" +
 	"\n" +
 	"# Config, change in the direnvrc\n" +
-	"DIRENV_LOG_FORMAT=\"${DIRENV_LOG_FORMAT-direnv: %%s}\"\n" +
+	"DIRENV_LOG_FORMAT=\"${DIRENV_LOG_FORMAT-direnv: %s}\"\n" +
 	"\n" +
 	"# Usage: direnv_layout_dir\n" +
 	"#\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -3,10 +3,11 @@
 # These are the commands available in an .envrc context
 #
 set -e
-direnv="%s"
+# NOTE: don't touch the RHS, it gets replaced at runtime
+direnv="$(which direnv)"
 
 # Config, change in the direnvrc
-DIRENV_LOG_FORMAT="${DIRENV_LOG_FORMAT-direnv: %%s}"
+DIRENV_LOG_FORMAT="${DIRENV_LOG_FORMAT-direnv: %s}"
 
 # Usage: direnv_layout_dir
 #


### PR DESCRIPTION
direnv tests fails when built from sources with golang-1.10. This was
reported in debian bug #890852.

The failure seems to be caused by incorrect escaping of '%' in 'direnv
stdlib'. Fix this by not using printf.

Add build test for go 1.10

Fixes #338