### PR TITLE
Add the usage of source_up to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ If you add the following line in "/a/b/.envrc", you can load both of the
 ```sh
 source_env ..
 ```
+In the general case `source_up` will load any .envrc higher up in the folder structure. This allows you to truely enable arbitrary heirarchical stuctures of `.envrc` usage.
+
+```sh
+source_up
+```
 
 ## Common things people don't know
 


### PR DESCRIPTION
This is far more useful than source_env (so much that possibly it should be default)