### PR TITLE
config: allow to disable stdin on eval

### DIFF
--- a/config.go
+++ b/config.go
@@ -18,13 +18,15 @@ type Config struct {
 	BashPath        string
 	RCDir           string
 	TomlPath        string
+	DisableStdin    bool
 	WhitelistPrefix []string
 	WhitelistExact  map[string]bool
 }
 
 type tomlConfig struct {
-	Whitelist whitelist `toml:"whitelist"`
-	BashPath  string    `toml:"bash_path"`
+	Whitelist    whitelist `toml:"whitelist"`
+	BashPath     string    `toml:"bash_path"`
+	DisableStdin bool      `toml:"disable_stdin"`
 }
 
 type whitelist struct {
@@ -92,6 +94,7 @@ func LoadConfig(env Env) (config *Config, err error) {
 			config.WhitelistExact[path] = true
 		}
 
+		config.DisableStdin = tomlConf.DisableStdin
 		config.BashPath = tomlConf.BashPath
 	}
 

--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -109,6 +109,10 @@ In this example, the following .envrc files will not be implicitly allowed (alth
 .PP
 This allows one to hard\-code the position of bash. It maybe be useful to set this to avoid having direnv to fail when PATH is being mutated.
 
+.SH \fB\fCdisable\_stdin\fR
+.PP
+If set to true, stdin is disabled (redirected to /dev/null) during the \fB\fC\&.envrc\fR evaluation.
+
 .SH COPYRIGHT
 .PP
 Copyright (C) 2018 zimbatm 

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -82,6 +82,10 @@ In this example, the following .envrc files will not be implicitly allowed (alth
 
 This allows one to hard-code the position of bash. It maybe be useful to set this to avoid having direnv to fail when PATH is being mutated.
 
+## `disable_stdin`
+
+If set to true, stdin is disabled (redirected to /dev/null) during the `.envrc` evaluation.
+
 COPYRIGHT
 ---------
 

--- a/rc.go
+++ b/rc.go
@@ -132,7 +132,15 @@ func (self *RC) Load(config *Config, env Env) (newEnv Env, err error) {
 	arg := fmt.Sprintf(argtmpl, direnv, self.RelTo(wd), direnv)
 	cmd := exec.Command(config.BashPath, "--noprofile", "--norc", "-c", arg)
 
-	cmd.Stdin = os.Stdin
+	if config.DisableStdin {
+		cmd.Stdin, err = os.Open(os.DevNull)
+		if err != nil {
+			return
+		}
+	} else {
+		cmd.Stdin = os.Stdin
+	}
+
 	cmd.Stderr = os.Stderr
 	cmd.Env = shellEnv.ToGoEnv()
 	cmd.Dir = wd


### PR DESCRIPTION
the `.envrc` shouldn't be interactive as it can be loaded from tooling

Fixes #350