### PR TITLE
Issue #303- check if dir is a symlink

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -180,7 +180,11 @@ const STDLIB = "#!bash\n" +
 	"  local rcpath=${1/#\\~/$HOME}\n" +
 	"  local rcfile\n" +
 	"  if ! [[ -f $rcpath ]]; then\n" +
-	"    rcpath=$rcpath/.envrc\n" +
+	"    if [[ -L \"$(pwd)\" ]]; then\n" +
+	"      rcpath=\"$(cd \"$(dirname \"$(pwd)/$rcpath\")\" && pwd)/.envrc\"\n" +
+	"    else\n" +
+	"      rcpath=$rcpath/.envrc\n" +
+	"    fi\n" +
 	"  fi\n" +
 	"\n" +
 	"  rcfile=$(user_rel_path \"$rcpath\")\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -178,7 +178,11 @@ source_env() {
   local rcpath=${1/#\~/$HOME}
   local rcfile
   if ! [[ -f $rcpath ]]; then
-    rcpath=$rcpath/.envrc
+    if [[ -L "$(pwd)" ]]; then
+      rcpath="$(cd "$(dirname "$(pwd)/$rcpath")" && pwd)/.envrc"
+    else
+      rcpath=$rcpath/.envrc
+    fi
   fi
 
   rcfile=$(user_rel_path "$rcpath")

--- a/test/direnv-test.sh
+++ b/test/direnv-test.sh
@@ -147,17 +147,11 @@ test_start "missing-file-source-env"
   direnv_eval
 test_stop
 
-# Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file
-# BUG: foo/bar is resolved in the .envrc execution context and so can't find
-#      the .envrc file.
-#
-# Apparently, the CHDIR syscall does that so I don't know how to work around
-# the issue.
-#
-# test_start "symlink-bug"
-#   cd foo/bar
-#   direnv_eval
-# test_stop
+test_start "symlink-bug"
+  direnv allow foo
+  cd foo/bar
+  direnv_eval
+test_stop
 
 # Pending: test that the mtime is looked on the original file
 # test_start "utils"

--- a/test/direnv-test.tcsh
+++ b/test/direnv-test.tcsh
@@ -118,17 +118,11 @@ cd $TEST_DIR/scenarios/"empty-var-unset"
   unsetenv FOO
 cd $TEST_DIR ; direnv_eval
 
-# Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file
-# BUG: foo/bar is resolved in the .envrc execution context and so can't find
-#      the .envrc file.
-#
-# Apparently, the CHDIR syscall does that so I don't know how to work around
-# the issue.
-#
-# cd $TEST_DIR/scenarios/"symlink-bug"
-#   cd foo/bar
-#   direnv_eval
-# cd $TEST_DIR ; direnv_eval
+cd $TEST_DIR/scenarios/"symlink-bug"
+  direnv allow foo
+  cd foo/bar
+  direnv_eval
+cd $TEST_DIR ; direnv_eval
 
 # Pending: test that the mtime is looked on the original file
 # cd $TEST_DIR/scenarios/"utils"


### PR DESCRIPTION
https://github.com/direnv/direnv/issues/303

Enabled and fixed the test case that was added and commented out 5 years ago.

Tested on Linux and macOS. (I ran the .sh test script, and made the same changes to the .tcsh script but didn't run it.)