### PR TITLE
Suggest default go src directory as location for cloning git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ nope
 Dependencies: make, golang
 
 ```bash
+cd ~/go/src
 git clone https://github.com/direnv/direnv
 cd direnv
 make install


### PR DESCRIPTION
For people who install go just for direnv and don't do additional configuration, the `make install` script only works inside directories that go expects.

Using both ubuntu and macOS the script failed with error messages that mentioned the Go install path and default `~/go/src` folder. Moving the direnv repository to the expected folder allowed the script to complete as expected.