### PR TITLE
stdlib: follow symlinks when looking for node

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -645,7 +645,7 @@ const STDLIB = "#!bash\n" +
 	"    # Strip $NODE_VERSIONS/$NODE_VERSION_PREFIX prefix from line.\n" +
 	"    # Sort by version: split by \".\" then reverse numeric sort for each piece of the version string\n" +
 	"    # The first one is the highest\n" +
-	"    find \"$NODE_VERSIONS\" -maxdepth 1 -mindepth 1 -type d -name \"$node_wanted*\" \\\n" +
+	"    find \"$NODE_VERSIONS\" -L -maxdepth 1 -mindepth 1 -type d -name \"$node_wanted*\" \\\n" +
 	"      | while IFS= read -r line; do echo \"${line#${NODE_VERSIONS%/}/${node_version_prefix}}\"; done \\\n" +
 	"      | sort -t . -k 1,1rn -k 2,2rn -k 3,3rn \\\n" +
 	"      | head -1\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -643,7 +643,7 @@ use_node() {
     # Strip $NODE_VERSIONS/$NODE_VERSION_PREFIX prefix from line.
     # Sort by version: split by "." then reverse numeric sort for each piece of the version string
     # The first one is the highest
-    find "$NODE_VERSIONS" -maxdepth 1 -mindepth 1 -type d -name "$node_wanted*" \
+    find "$NODE_VERSIONS" -L -maxdepth 1 -mindepth 1 -type d -name "$node_wanted*" \
       | while IFS= read -r line; do echo "${line#${NODE_VERSIONS%/}/${node_version_prefix}}"; done \
       | sort -t . -k 1,1rn -k 2,2rn -k 3,3rn \
       | head -1


### PR DESCRIPTION
Symlinks should be treated as a way to change the file hierachy.

Fixes #365