### PR TITLE
handle `$PIPENV_PIPFILE`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /test/allow
 /test/config/direnv/allow
 *.sw?
+/.idea

--- a/stdlib.go
+++ b/stdlib.go
@@ -480,8 +480,9 @@ const STDLIB = "#!bash\n" +
 	"# virtualenv from the Pipfile located in the same directory.\n" +
 	"#\n" +
 	"layout_pipenv() {\n" +
-	"  if [[ ! -f Pipfile ]]; then\n" +
-	"    log_error 'No Pipfile found.  Use `pipenv` to create a Pipfile first.'\n" +
+	"  PIPENV_PIPFILE=\"${PIPENV_PIPFILE:-Pipfile}\"\n" +
+	"  if [[ ! -f \"$PIPENV_PIPFILE\" ]]; then\n" +
+	"    log_error \"No Pipfile found.  Use `pipenv` to create a `$PIPENV_PIPFILE` first.\"\n" +
 	"    exit 2\n" +
 	"  fi\n" +
 	"\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -478,8 +478,9 @@ layout_anaconda() {
 # virtualenv from the Pipfile located in the same directory.
 #
 layout_pipenv() {
-  if [[ ! -f Pipfile ]]; then
-    log_error 'No Pipfile found.  Use `pipenv` to create a Pipfile first.'
+  PIPENV_PIPFILE="${PIPENV_PIPFILE:-Pipfile}"
+  if [[ ! -f "$PIPENV_PIPFILE" ]]; then
+    log_error "No Pipfile found.  Use `pipenv` to create a `$PIPENV_PIPFILE` first."
     exit 2
   fi
 


### PR DESCRIPTION
Adds handling of `PIPENV_PIPFILE` environment variable,
allowing this:
```bash
export PIPENV_PIPFILE="${PWD}/app/Pipfile"
layout_pipenv
```
instead of this:
```bash
cd "${PWD}/app"
layout_pipenv
cd -
```