### PR TITLE
Don't download elvish during the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ man: $(ROFFS)
 test: build
 	go test
 	./test/direnv-test.sh
-	go get github.com/elves/elvish
 	elvish ./test/direnv-test.elv
 
 install: all


### PR DESCRIPTION
Elvish needs to be added as an external dependency rather than downloaded and built during the build.

Drop the step to download elvish in the Makefile.

Closes #372 