### PR TITLE
adds experimental curl based installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ nope
 
 ## Install
 
+If you are brave enough to try the experimental curl based installer run:
+
+```
+curl -s https://github.com/direnv/direnv/get-direnv | bash
+```
+
 ### From system packages
 
 direnv is packaged for a variety of systems:

--- a/get-direnv
+++ b/get-direnv
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -eou pipefail
+
+# Determine OS platform
+UNAME=$(uname | tr "[:upper:]" "[:lower:]")
+# If Linux, try to determine specific distribution
+if [ "$UNAME" == "linux" ]; then
+    # If available, use LSB to identify distribution
+    if [ -f /etc/lsb-release -o -d /etc/lsb-release.d ]; then
+        export DISTRO=$(lsb_release -i | cut -d: -f2 | sed s/'^\t'//)
+    # Otherwise, use release info file
+    else
+        export DISTRO=$(ls -d /etc/[A-Za-z]*[_-][rv]e[lr]* | grep -v "lsb" | cut -d'/' -f3 | cut -d'-' -f1 | cut -d'_' -f1)
+    fi
+fi
+# For everything else (or if above failed), just use generic identifier
+[ "${DISTRO:-}" == "" ] && export DISTRO=$UNAME
+unset UNAME
+
+echo $DISTRO
+
+which go >/dev/null || {
+    if [ "${DISTRO}" == "darwin" ]; then
+        brew install go
+    elif [ "${DISTRO}" == "CentOS" ]; then
+        sudo yum install -q -y golang
+    fi
+}
+
+if [ ! -d ~/go/src/github.com/direnv ]; then
+    LANG=C git clone https://github.com/direnv/direnv ~/go/src/github.com/direnv
+fi
+pushd ~/go/src/github.com/direnv >/dev/null
+    git pull
+    GOPATH=$HOME/go PATH=$PATH:$GOPATH/bin
+    GOBIN=~/.local/bin go install
+popd >/dev/null
+
+which -a direnv >/dev/null
+
+# install zsh hook if not already present
+if [ -f ~/.zshrc ]; then
+  grep -qF 'eval "$(direnv hook zsh)"' ~/.zshrc || \
+    sed -i '$a eval "$(direnv hook zsh)"' ~/.zshrc
+fi
+
+echo "--- done ---"

--- a/get-direnv
+++ b/get-direnv
@@ -44,4 +44,31 @@ if [ -f ~/.zshrc ]; then
     sed -i '$a eval "$(direnv hook zsh)"' ~/.zshrc
 fi
 
+# install bash hook if not already present
+if [ -f ~/.bashrc ]; then
+  grep -qF 'eval "$(direnv hook bash)"' ~/.bashrc || \
+    sed -i '$a eval "$(direnv hook bash)"' ~/.bashrc
+fi
+
+# install fish hook if not already present
+if [ -f ~/.config/fish/config.fish ]; then
+  grep -qF 'eval "$(direnv hook fish)"' ~/.config/fish/config.fish || \
+    sed -i '$a eval "$(direnv hook fish)"' ~/.config/fish/config.fish
+fi
+
+# install tcsh hook if not already present
+if [ -f ~/.cshrc ]; then
+  grep -qF 'eval "$(direnv hook tcsh)"' ~/.cshrc || \
+    sed -i '$a eval "$(direnv hook tcsh)"' ~/.cshrc
+fi
+
+# install elvish hook if not already present
+if [ -d ~/.elvish/lib ]; then
+  direnv hook elvish > ~/.elvish/lib/direnv.elv
+fi
+if [ -f ~/.elvish/rc.elv ]; then
+  grep -qF 'use direnv' ~/.elvish/rc.elv || \
+    sed -i '$a use direnv' ~/.elvish/rc.elv
+fi
+
 echo "--- done ---"


### PR DESCRIPTION
Curl installer is supposed to ease deployment by automating
all install steps.

This first version will build the code but in the future
we may want to add option for binary install.