### PR TITLE
Avoid to add unnecessary trailing semicolon character

### DIFF
--- a/shell_bash.go
+++ b/shell_bash.go
@@ -13,7 +13,7 @@ _direnv_hook() {
   return $previous_exit_status;
 };
 if ! [[ "$PROMPT_COMMAND" =~ _direnv_hook ]]; then
-  PROMPT_COMMAND="_direnv_hook;$PROMPT_COMMAND";
+  PROMPT_COMMAND="_direnv_hook;$PROMPT_COMMAND"
 fi
 `
 


### PR DESCRIPTION
If the original PROMPT_COMMAND ends with semicolon, the extra one will cause
bash script throw "syntax error" because of double semicolon in the
PROMPT_COMMAND.