### PR TITLE
Add julia layout to stdlib

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -547,6 +547,13 @@ const STDLIB = "#!bash\n" +
 	"  PATH_add \"$BUNDLE_BIN\"\n" +
 	"}\n" +
 	"\n" +
+	"# Usage: layout julia\n" +
+	"#\n" +
+	"# Sets the JULIA_PROJECT environment variable to the current directory.\n" +
+	"layout_julia() {\n" +
+	"  export JULIA_PROJECT=$PWD\n" +
+	"}\n" +
+	"\n" +
 	"# Usage: use <program_name> [<version>]\n" +
 	"#\n" +
 	"# A semantic command dispatch intended for loading external dependencies into\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -545,6 +545,13 @@ layout_ruby() {
   PATH_add "$BUNDLE_BIN"
 }
 
+# Usage: layout julia
+#
+# Sets the JULIA_PROJECT environment variable to the current directory.
+layout_julia() {
+  export JULIA_PROJECT=$PWD
+}
+
 # Usage: use <program_name> [<version>]
 #
 # A semantic command dispatch intended for loading external dependencies into


### PR DESCRIPTION
A few notes:

- This works on julia 0.7 and higher.  The package manager was rewritten for julia 0.7, and it now has a stable interface with the release of julia 1.0.
- I was a bit confused about whether it should be called `layout_julia` or `use_julia`.  It seems similar conceptually to both `layout_go` and `use_guix`.  Note that the julia environment itself is specified by files called `Project.toml` and `Manifest.toml` (alternatively called `JuliaProject.toml` and `JuliaManifest.toml`).  Full documentation on julia's package manager [is available here](https://docs.julialang.org/en/latest/stdlib/Pkg/).
- I am unsure whether julia environments may contain a `bin` directory which should be added to the `PATH`.  I will check with julia developers and may update this pull request once I learn the answer.
- I plan to also solicit feedback from other julia developers.
- I have tested this locally.