### PR TITLE
direnv show_dump: new command to debug encoded env

### DIFF
--- a/cmd_show_dump.go
+++ b/cmd_show_dump.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// `direnv show_dump`
+var CmdShowDump = &Cmd{
+	Name:    "show_dump",
+	Desc:    "Show the data inside of a dump for debugging purposes",
+	Args:    []string{"DUMP"},
+	Private: true,
+	Fn: func(env Env, args []string) (err error) {
+		if len(args) < 2 {
+			return fmt.Errorf("Missing DUMP argument")
+		}
+
+		var f interface{}
+		err = unmarshal(args[1], &f)
+		if err != nil {
+			return err
+		}
+
+		e := json.NewEncoder(os.Stdout)
+		e.SetIndent("", "  ")
+		return e.Encode(f)
+	},
+}

--- a/commands.go
+++ b/commands.go
@@ -22,6 +22,7 @@ func init() {
 	CmdList = []*Cmd{
 		CmdAllow,
 		CmdApplyDump,
+		CmdShowDump,
 		CmdDeny,
 		CmdDotEnv,
 		CmdDump,


### PR DESCRIPTION
This is a private command used to debug when things go wrong. It can
decode and print the content of a DIRENV_DIFF or the output of `direnv
dump`.

Used to debug #394