### PR TITLE
README: add packaging status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@ direnv is packaged for a variety of systems:
 * [Ubuntu](https://packages.ubuntu.com/search?keywords=direnv&searchon=names&suite=all&section=all)
 * [GNU Guix](https://www.gnu.org/software/guix/)
 
-Non-official builds for Debian and Fedora are also available at
-https://dl.equinox.io/zimbatm/direnv/stable
-
 ### From binary builds
 
 Binary builds for a variety of architectures are also available for

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ direnv is packaged for a variety of systems:
 * [Ubuntu](https://packages.ubuntu.com/search?keywords=direnv&searchon=names&suite=all&section=all)
 * [GNU Guix](https://www.gnu.org/software/guix/)
 
+See also:
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/direnv.svg)](https://repology.org/metapackage/direnv)
+
 ### From binary builds
 
 Binary builds for a variety of architectures are also available for


### PR DESCRIPTION
Add packaging status from repology. This gives a better idea if your
favourite distribution has it.

[Rendered view](https://github.com/zimbatm/direnv/tree/readme-packaging-status/#from-system-packages)