### PR TITLE
deny: persist the denial to avoid shell abuse with error messages

### DIFF
--- a/config.go
+++ b/config.go
@@ -113,6 +113,11 @@ func (self *Config) AllowDir() string {
 	return filepath.Join(self.ConfDir, "allow")
 }
 
+// DenyDir returns the directory under which we store the denials
+func (self *Config) DenyDir() string {
+	return filepath.Join(self.ConfDir, "deny")
+}
+
 func (self *Config) LoadedRC() *RC {
 	if self.RCDir == "" {
 		log_debug("RCDir is blank - loadedRC is nil")


### PR DESCRIPTION
This commit extends the `deny` command to write down `$XDG_CONFIG_HOME/.direnv/deny/<hash>` similar to how the `allow` command persists the allow based on the hash.

closes #259