### PR TITLE
Correctes spelling of openSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ direnv is packaged for a variety of systems:
 * [NetBSD pkgsrc-wip](http://www.pkgsrc.org/wip/)
 * [NixOS](https://nixos.org/nixos/packages.html)
 * [OSX Homebrew](http://brew.sh/)
-* [OpenSuSe](https://build.opensuse.org/package/show/openSUSE%3AFactory/direnv)
+* [openSUSE](https://build.opensuse.org/package/show/openSUSE%3AFactory/direnv)
 * [MacPorts](https://www.macports.org/)
 * [Ubuntu](https://packages.ubuntu.com/search?keywords=direnv&searchon=names&suite=all&section=all)
 * [GNU Guix](https://www.gnu.org/software/guix/)


### PR DESCRIPTION
Nowadays it's just "openSUSE". The upper and lower-case version of SuSe isn't used anymore.