### PR TITLE
add optional "bash" argument to `direnv dump`

### DIFF
--- a/cmd_dump.go
+++ b/cmd_dump.go
@@ -6,9 +6,22 @@ import "fmt"
 var CmdDump = &Cmd{
 	Name:    "dump",
 	Desc:    "Used to export the inner bash state at the end of execution",
+	Args:    []string{"[SHELL]"},
 	Private: true,
 	Fn: func(env Env, args []string) (err error) {
-		fmt.Println(env.Serialize())
+		target := "gzenv"
+
+		if len(args) > 1 {
+			target = args[1]
+		}
+
+		shell := DetectShell(target)
+		if shell == nil {
+			return fmt.Errorf("Unknown target shell '%s'", target)
+		}
+
+		fmt.Println(shell.Dump(env))
+
 		return
 	},
 }

--- a/cmd_show_dump.go
+++ b/cmd_show_dump.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/direnv/direnv/gzenv"
 )
 
 // `direnv show_dump`
@@ -18,7 +20,7 @@ var CmdShowDump = &Cmd{
 		}
 
 		var f interface{}
-		err = unmarshal(args[1], &f)
+		err = gzenv.Unmarshal(args[1], &f)
 		if err != nil {
 			return err
 		}

--- a/env.go
+++ b/env.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 	"strings"
+
+	"github.com/direnv/direnv/gzenv"
 )
 
 type Env map[string]string
@@ -31,9 +33,9 @@ func (env Env) CleanContext() {
 	delete(env, DIRENV_DIFF)
 }
 
-func LoadEnv(base64env string) (env Env, err error) {
+func LoadEnv(gzenvStr string) (env Env, err error) {
 	env = make(Env)
-	err = unmarshal(base64env, &env)
+	err = gzenv.Unmarshal(gzenvStr, &env)
 	return
 }
 
@@ -68,7 +70,7 @@ func (env Env) ToShell(shell Shell) string {
 }
 
 func (env Env) Serialize() string {
-	return marshal(env)
+	return gzenv.Marshal(env)
 }
 
 func (e1 Env) Diff(e2 Env) *EnvDiff {

--- a/env_diff.go
+++ b/env_diff.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"strings"
+
+	"github.com/direnv/direnv/gzenv"
 )
 
 // A list of keys we don't want to deal with
@@ -60,9 +62,9 @@ func BuildEnvDiff(e1, e2 Env) *EnvDiff {
 	return diff
 }
 
-func LoadEnvDiff(base64env string) (diff *EnvDiff, err error) {
+func LoadEnvDiff(gzenvStr string) (diff *EnvDiff, err error) {
 	diff = new(EnvDiff)
-	err = unmarshal(base64env, diff)
+	err = gzenv.Unmarshal(gzenvStr, diff)
 	return
 }
 
@@ -110,7 +112,7 @@ func (self *EnvDiff) Reverse() *EnvDiff {
 }
 
 func (self *EnvDiff) Serialize() string {
-	return marshal(self)
+	return gzenv.Marshal(self)
 }
 
 //// Utils

--- a/file_times.go
+++ b/file_times.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/direnv/direnv/gzenv"
 )
 
 type FileTime struct {
@@ -141,9 +143,9 @@ func (self *FileTime) Formatted(relDir string) string {
 }
 
 func (times *FileTimes) Marshal() string {
-	return marshal(*times.list)
+	return gzenv.Marshal(*times.list)
 }
 
 func (times *FileTimes) Unmarshal(from string) error {
-	return unmarshal(from, times.list)
+	return gzenv.Unmarshal(from, times.list)
 }

--- a/gzenv/gzenv.go
+++ b/gzenv/gzenv.go
@@ -1,4 +1,6 @@
-package main
+// the gzenv format: json+gzip+base64
+// a quickly designed format to export the whole environment back into itself
+package gzenv
 
 import (
 	"bytes"
@@ -10,7 +12,8 @@ import (
 	"strings"
 )
 
-func marshal(obj interface{}) string {
+// Marshal encodes the object into the gzenv format
+func Marshal(obj interface{}) string {
 	jsonData, err := json.Marshal(obj)
 
 	if err != nil {
@@ -27,10 +30,11 @@ func marshal(obj interface{}) string {
 	return base64Data
 }
 
-func unmarshal(base64env string, obj interface{}) error {
-	base64env = strings.TrimSpace(base64env)
+// Unmarshal restores the gzenv format back into a Go object
+func Unmarshal(gzenv string, obj interface{}) error {
+	gzenv = strings.TrimSpace(gzenv)
 
-	data, err := base64.URLEncoding.DecodeString(base64env)
+	data, err := base64.URLEncoding.DecodeString(gzenv)
 	if err != nil {
 		return fmt.Errorf("unmarshal() base64 decoding: %v", err)
 	}

--- a/shell.go
+++ b/shell.go
@@ -10,6 +10,7 @@ import (
 type Shell interface {
 	Hook() (string, error)
 	Export(e ShellExport) string
+	Dump(env Env) string
 }
 
 // Used to describe what to generate for the shell

--- a/shell.go
+++ b/shell.go
@@ -38,6 +38,8 @@ func DetectShell(target string) Shell {
 		return ZSH
 	case "fish":
 		return FISH
+	case "gzenv":
+		return GZENV
 	case "vim":
 		return VIM
 	case "tcsh":

--- a/shell_bash.go
+++ b/shell_bash.go
@@ -2,9 +2,9 @@ package main
 
 import "fmt"
 
-type bash int
+type bash struct{}
 
-var BASH bash
+var BASH Shell = bash{}
 
 const BASH_HOOK = `
 _direnv_hook() {
@@ -17,30 +17,30 @@ if ! [[ "$PROMPT_COMMAND" =~ _direnv_hook ]]; then
 fi
 `
 
-func (b bash) Hook() (string, error) {
+func (sh bash) Hook() (string, error) {
 	return BASH_HOOK, nil
 }
 
-func (b bash) Export(e ShellExport) (out string) {
+func (sh bash) Export(e ShellExport) (out string) {
 	for key, value := range e {
 		if value == nil {
-			out += b.unset(key)
+			out += sh.unset(key)
 		} else {
-			out += b.export(key, *value)
+			out += sh.export(key, *value)
 		}
 	}
 	return out
 }
 
-func (b bash) export(key, value string) string {
-	return "export " + b.escape(key) + "=" + b.escape(value) + ";"
+func (sh bash) export(key, value string) string {
+	return "export " + sh.escape(key) + "=" + sh.escape(value) + ";"
 }
 
-func (b bash) unset(key string) string {
-	return "unset " + b.escape(key) + ";"
+func (sh bash) unset(key string) string {
+	return "unset " + sh.escape(key) + ";"
 }
 
-func (b bash) escape(str string) string {
+func (sh bash) escape(str string) string {
 	return BashEscape(str)
 }
 

--- a/shell_bash.go
+++ b/shell_bash.go
@@ -32,6 +32,13 @@ func (sh bash) Export(e ShellExport) (out string) {
 	return out
 }
 
+func (sh bash) Dump(env Env) (out string) {
+	for key, value := range env {
+		out += sh.export(key, value)
+	}
+	return out
+}
+
 func (sh bash) export(key, value string) string {
 	return "export " + sh.escape(key) + "=" + sh.escape(value) + ";"
 }

--- a/shell_elvish.go
+++ b/shell_elvish.go
@@ -7,7 +7,7 @@ import (
 
 type elvish struct{}
 
-var ELVISH = elvish{}
+var ELVISH Shell = elvish{}
 
 func (elvish) Hook() (string, error) {
 	return `## hook for direnv

--- a/shell_elvish.go
+++ b/shell_elvish.go
@@ -37,6 +37,15 @@ func (sh elvish) Export(e ShellExport) string {
 	return buf.String()
 }
 
+func (sh elvish) Dump(env Env) (out string) {
+	buf := new(bytes.Buffer)
+	err := json.NewEncoder(buf).Encode(env)
+	if err != nil {
+		panic(err)
+	}
+	return buf.String()
+}
+
 var (
 	_ Shell = (*elvish)(nil)
 )

--- a/shell_fish.go
+++ b/shell_fish.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-type fish int
+type fish struct{}
 
-var FISH fish
+var FISH Shell = fish{}
 
 const FISH_HOOK = `
 function __direnv_export_eval --on-event fish_prompt;
@@ -15,37 +15,37 @@ function __direnv_export_eval --on-event fish_prompt;
 end
 `
 
-func (f fish) Hook() (string, error) {
+func (sh fish) Hook() (string, error) {
 	return FISH_HOOK, nil
 }
 
-func (f fish) Export(e ShellExport) (out string) {
+func (sh fish) Export(e ShellExport) (out string) {
 	for key, value := range e {
 		if value == nil {
-			out += f.unset(key)
+			out += sh.unset(key)
 		} else {
-			out += f.export(key, *value)
+			out += sh.export(key, *value)
 		}
 	}
 	return out
 }
 
-func (f fish) export(key, value string) string {
+func (sh fish) export(key, value string) string {
 	if key == "PATH" {
 		command := "set -x -g PATH"
 		for _, path := range strings.Split(value, ":") {
-			command += " " + f.escape(path)
+			command += " " + sh.escape(path)
 		}
 		return command + ";"
 	}
-	return "set -x -g " + f.escape(key) + " " + f.escape(value) + ";"
+	return "set -x -g " + sh.escape(key) + " " + sh.escape(value) + ";"
 }
 
-func (f fish) unset(key string) string {
-	return "set -e -g " + f.escape(key) + ";"
+func (sh fish) unset(key string) string {
+	return "set -e -g " + sh.escape(key) + ";"
 }
 
-func (f fish) escape(str string) string {
+func (sh fish) escape(str string) string {
 	in := []byte(str)
 	out := "'"
 	i := 0

--- a/shell_fish.go
+++ b/shell_fish.go
@@ -30,6 +30,13 @@ func (sh fish) Export(e ShellExport) (out string) {
 	return out
 }
 
+func (sh fish) Dump(env Env) (out string) {
+	for key, value := range env {
+		out += sh.export(key, value)
+	}
+	return out
+}
+
 func (sh fish) export(key, value string) string {
 	if key == "PATH" {
 		command := "set -x -g PATH"

--- a/shell_gzenv.go
+++ b/shell_gzenv.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/direnv/direnv/gzenv"
+)
+
+// gzenvShell is not a real shell. used for internal purposes.
+type gzenvShell int
+
+var GZENV Shell = gzenvShell(0)
+
+func (s gzenvShell) Hook() (string, error) {
+	return "", errors.New("the gzenv shell doesn't support hooking")
+}
+
+func (s gzenvShell) Export(e ShellExport) string {
+	return gzenv.Marshal(e)
+}
+
+func (s gzenvShell) Dump(env Env) string {
+	return gzenv.Marshal(env)
+}

--- a/shell_json.go
+++ b/shell_json.go
@@ -22,3 +22,12 @@ func (sh jsonShell) Export(e ShellExport) string {
 	}
 	return string(out)
 }
+
+func (sh jsonShell) Dump(env Env) string {
+	out, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		// Should never happen
+		panic(err)
+	}
+	return string(out)
+}

--- a/shell_json.go
+++ b/shell_json.go
@@ -5,15 +5,16 @@ import (
 	"errors"
 )
 
-type jsonShell int
+// jsonShell is not a real shell
+type jsonShell struct{}
 
-var JSON jsonShell
+var JSON Shell = jsonShell{}
 
-func (s jsonShell) Hook() (string, error) {
+func (sh jsonShell) Hook() (string, error) {
 	return "", errors.New("this feature is not supported")
 }
 
-func (s jsonShell) Export(e ShellExport) string {
+func (sh jsonShell) Export(e ShellExport) string {
 	out, err := json.MarshalIndent(e, "", "  ")
 	if err != nil {
 		// Should never happen

--- a/shell_tcsh.go
+++ b/shell_tcsh.go
@@ -24,6 +24,13 @@ func (sh tcsh) Export(e ShellExport) (out string) {
 	return out
 }
 
+func (sh tcsh) Dump(env Env) (out string) {
+	for key, value := range env {
+		out += sh.export(key, value)
+	}
+	return out
+}
+
 func (sh tcsh) export(key, value string) string {
 	if key == "PATH" {
 		command := "set path = ("

--- a/shell_tcsh.go
+++ b/shell_tcsh.go
@@ -5,41 +5,41 @@ import (
 	"strings"
 )
 
-type tcsh int
+type tcsh struct{}
 
-var TCSH tcsh
+var TCSH Shell = tcsh{}
 
-func (f tcsh) Hook() (string, error) {
+func (sh tcsh) Hook() (string, error) {
 	return "alias precmd 'eval `{{.SelfPath}} export tcsh`'", nil
 }
 
-func (f tcsh) Export(e ShellExport) (out string) {
+func (sh tcsh) Export(e ShellExport) (out string) {
 	for key, value := range e {
 		if value == nil {
-			out += f.unset(key)
+			out += sh.unset(key)
 		} else {
-			out += f.export(key, *value)
+			out += sh.export(key, *value)
 		}
 	}
 	return out
 }
 
-func (f tcsh) export(key, value string) string {
+func (sh tcsh) export(key, value string) string {
 	if key == "PATH" {
 		command := "set path = ("
 		for _, path := range strings.Split(value, ":") {
-			command += " " + f.escape(path)
+			command += " " + sh.escape(path)
 		}
 		return command + " );"
 	}
-	return "setenv " + f.escape(key) + " " + f.escape(value) + " ;"
+	return "setenv " + sh.escape(key) + " " + sh.escape(value) + " ;"
 }
 
-func (f tcsh) unset(key string) string {
-	return "unsetenv " + f.escape(key) + " ;"
+func (sh tcsh) unset(key string) string {
+	return "unsetenv " + sh.escape(key) + " ;"
 }
 
-func (f tcsh) escape(str string) string {
+func (sh tcsh) escape(str string) string {
 	if str == "" {
 		return "''"
 	}

--- a/shell_vim.go
+++ b/shell_vim.go
@@ -5,39 +5,39 @@ import (
 	"strings"
 )
 
-type vim int
+type vim struct{}
 
-var VIM vim
+var VIM Shell = vim{}
 
-func (x vim) Hook() (string, error) {
+func (sh vim) Hook() (string, error) {
 	return "", errors.New("this feature is not supported. Install the direnv.vim plugin instead.")
 }
 
-func (x vim) Export(e ShellExport) (out string) {
+func (sh vim) Export(e ShellExport) (out string) {
 	for key, value := range e {
 		if value == nil {
-			out += x.unset(key)
+			out += sh.unset(key)
 		} else {
-			out += x.export(key, *value)
+			out += sh.export(key, *value)
 		}
 	}
 	return out
 }
 
-func (x vim) export(key, value string) string {
-	return "let $" + x.escapeKey(key) + " = " + x.escapeValue(value) + "\n"
+func (sh vim) export(key, value string) string {
+	return "let $" + sh.escapeKey(key) + " = " + sh.escapeValue(value) + "\n"
 }
 
-func (x vim) unset(key string) string {
-	return "let $" + x.escapeKey(key) + " = ''\n"
+func (sh vim) unset(key string) string {
+	return "let $" + sh.escapeKey(key) + " = ''\n"
 }
 
 // TODO: support keys with special chars or fail
-func (x vim) escapeKey(str string) string {
+func (sh vim) escapeKey(str string) string {
 	return str
 }
 
 // TODO: Make sure this escaping is valid
-func (x vim) escapeValue(str string) string {
+func (sh vim) escapeValue(str string) string {
 	return "'" + strings.Replace(str, "'", "''", -1) + "'"
 }

--- a/shell_vim.go
+++ b/shell_vim.go
@@ -24,6 +24,13 @@ func (sh vim) Export(e ShellExport) (out string) {
 	return out
 }
 
+func (sh vim) Dump(env Env) (out string) {
+	for key, value := range env {
+		out += sh.export(key, value)
+	}
+	return out
+}
+
 func (sh vim) export(key, value string) string {
 	return "let $" + sh.escapeKey(key) + " = " + sh.escapeValue(value) + "\n"
 }

--- a/shell_zsh.go
+++ b/shell_zsh.go
@@ -30,6 +30,13 @@ func (sh zsh) Export(e ShellExport) (out string) {
 	return out
 }
 
+func (sh zsh) Dump(env Env) (out string) {
+	for key, value := range env {
+		out += sh.export(key, value)
+	}
+	return out
+}
+
 func (sh zsh) export(key, value string) string {
 	return "export " + sh.escape(key) + "=" + sh.escape(value) + ";"
 }

--- a/shell_zsh.go
+++ b/shell_zsh.go
@@ -1,9 +1,9 @@
 package main
 
 // ZSH is a singleton instance of ZSH_T
-type zsh int
+type zsh struct{}
 
-var ZSH zsh
+var ZSH Shell = zsh{}
 
 const ZSH_HOOK = `
 _direnv_hook() {
@@ -15,29 +15,29 @@ if [[ -z ${precmd_functions[(r)_direnv_hook]} ]]; then
 fi
 `
 
-func (z zsh) Hook() (string, error) {
+func (sh zsh) Hook() (string, error) {
 	return ZSH_HOOK, nil
 }
 
-func (z zsh) Export(e ShellExport) (out string) {
+func (sh zsh) Export(e ShellExport) (out string) {
 	for key, value := range e {
 		if value == nil {
-			out += z.unset(key)
+			out += sh.unset(key)
 		} else {
-			out += z.export(key, *value)
+			out += sh.export(key, *value)
 		}
 	}
 	return out
 }
 
-func (z zsh) export(key, value string) string {
-	return "export " + z.escape(key) + "=" + z.escape(value) + ";"
+func (sh zsh) export(key, value string) string {
+	return "export " + sh.escape(key) + "=" + sh.escape(value) + ";"
 }
 
-func (z zsh) unset(key string) string {
-	return "unset " + z.escape(key) + ";"
+func (sh zsh) unset(key string) string {
+	return "unset " + sh.escape(key) + ";"
 }
 
-func (z zsh) escape(str string) string {
+func (sh zsh) escape(str string) string {
 	return BashEscape(str)
 }


### PR DESCRIPTION
This is useful in scenarios where an environment is cached between runs

Fixes some of #405 . Only for commands with a --pure option similar to nix-shell.