### PR TITLE
file_times: use Lstat as well as Stat

### DIFF
--- a/test/direnv-test.bash
+++ b/test/direnv-test.bash
@@ -156,6 +156,19 @@ test_start "missing-file-source-env"
   direnv_eval
 test_stop
 
+test_start "symlink-changed"
+  # when using a symlink, reload if the symlink changes, or if the
+  # target file changes.
+
+  ln -fs ./state-A ./symlink
+  direnv_eval
+  test_eq "${STATE}" "A"
+
+  ln -fs ./state-B ./symlink
+  direnv_eval
+  test_eq "${STATE}" "B"
+test_stop
+
 # Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file
 # BUG: foo/bar is resolved in the .envrc execution context and so can't find
 #      the .envrc file.

--- a/test/scenarios/symlink-changed/.envrc
+++ b/test/scenarios/symlink-changed/.envrc
@@ -1,0 +1,2 @@
+watch_file ./symlink
+. ./symlink

--- a/test/scenarios/symlink-changed/.gitignore
+++ b/test/scenarios/symlink-changed/.gitignore
@@ -1,0 +1,1 @@
+symlink

--- a/test/scenarios/symlink-changed/state-A
+++ b/test/scenarios/symlink-changed/state-A
@@ -1,0 +1,1 @@
+export STATE=A

--- a/test/scenarios/symlink-changed/state-B
+++ b/test/scenarios/symlink-changed/state-B
@@ -1,0 +1,1 @@
+export STATE=B


### PR DESCRIPTION
Stat only looks at the target of symlinks, and Lstat
examines the symlink itself.

This change allows changes to both the symlink and
the symlink's target to trigger updates.