### PR TITLE
file_times: check Stat and Lstat

### DIFF
--- a/file_times.go
+++ b/file_times.go
@@ -29,9 +29,7 @@ func (times *FileTimes) Update(path string) (err error) {
 	var modtime int64
 	var exists bool
 
-	// Handle the path with Stat, which looks at the other
-	// end of symlinks
-	stat, err := os.Stat(path)
+	stat, err := getLatestStat(path)
 	if os.IsNotExist(err) {
 		exists = false
 	} else {
@@ -40,28 +38,6 @@ func (times *FileTimes) Update(path string) (err error) {
 			return
 		}
 		modtime = stat.ModTime().Unix()
-	}
-
-	// Handle the path with Lstat, which examines the
-	// symlink itself.
-	//
-	// This second case is useful in case the symlink
-	// changes where it is pointing, and should handle
-	// the case where the symlink's target doesn't exist.
-	stat, err = os.Lstat(path)
-	if os.IsNotExist(err) {
-		exists = false
-	} else {
-		exists = true
-		if err != nil {
-			return
-		}
-		symlink_modtime := stat.ModTime().Unix()
-
-		if symlink_modtime > modtime {
-			// take the newest of the two
-			modtime = symlink_modtime
-		}
 	}
 
 	err = times.NewTime(path, modtime, exists)
@@ -133,21 +109,23 @@ func (times *FileTimes) CheckOne(path string) (err error) {
 }
 
 func (time FileTime) Check() (err error) {
-	stat, err := os.Stat(time.Path)
+	stat, err := getLatestStat(time.Path)
+
 	switch {
 	case os.IsNotExist(err):
 		if time.Exists {
-			log_debug("Check: %s: gone", time.Path)
-			return checkFailed{fmt.Sprintf("File %q is missing", time.Path)}
+			log_debug("Stat Check: %s: gone", time.Path)
+			return checkFailed{fmt.Sprintf("File %q is missing (Stat)", time.Path)}
 		}
 	case err != nil:
-		log_debug("Check: %s: ERR: %v", time.Path, err)
+		log_debug("Stat Check: %s: ERR: %v", time.Path, err)
 		return err
 	case !time.Exists:
 		log_debug("Check: %s: appeared", time.Path)
 		return checkFailed{fmt.Sprintf("File %q newly created", time.Path)}
 	case stat.ModTime().Unix() != time.Modtime:
-		log_debug("Check: %s: stale", time.Path)
+		log_debug("Check: %s: stale (stat: %v, lastcheck: %v)",
+			time.Path, stat.ModTime().Unix(), time.Modtime)
 		return checkFailed{fmt.Sprintf("File %q has changed", time.Path)}
 	}
 	log_debug("Check: %s: up to date", time.Path)
@@ -172,4 +150,36 @@ func (times *FileTimes) Marshal() string {
 
 func (times *FileTimes) Unmarshal(from string) error {
 	return gzenv.Unmarshal(from, times.list)
+}
+
+func getLatestStat(path string) (os.FileInfo, error) {
+	var lstat_modtime int64
+	var stat_modtime int64
+
+	// Check the examine-a-symlink case first:
+	lstat, err := os.Lstat(path)
+	if err != nil {
+		log_debug("getLatestStat,Lstat: %s: error: %v", path, err)
+		return nil, err
+	}
+	lstat_modtime = lstat.ModTime().Unix()
+
+	stat, err := os.Stat(path)
+	if err != nil {
+		log_debug("getLatestStat,Stat: %s: error: %v (Lstat time: %v)",
+			path, err, lstat_modtime)
+		return nil, err
+	}
+	stat_modtime = stat.ModTime().Unix()
+
+	if lstat_modtime > stat_modtime {
+		log_debug("getLatestStat: %s: Lstat: %v, Stat: %v -> preferring Lstat",
+			path, lstat_modtime, stat_modtime)
+		return lstat, nil
+	} else {
+		log_debug("getLatestStat: %s: Lstat: %v, Stat: %v -> preferring Stat",
+			path, lstat_modtime, stat_modtime)
+		return stat, nil
+	}
+
 }

--- a/test/direnv-test.bash
+++ b/test/direnv-test.bash
@@ -159,10 +159,10 @@ test_stop
 test_start "symlink-changed"
   # when using a symlink, reload if the symlink changes, or if the
   # target file changes.
-
   ln -fs ./state-A ./symlink
   direnv_eval
   test_eq "${STATE}" "A"
+  sleep 1
 
   ln -fs ./state-B ./symlink
   direnv_eval


### PR DESCRIPTION
Only trigger a reload if either Stat or Lstat don't match the expected
time exactly.

Before this patch, if direnv was watching a symlink, direnv always
thought the file was stale, because the Lstat didn't match the Stat
results.