### PR TITLE
Add shell-specific actions and use them to implement aliases

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -143,6 +143,7 @@ test-fish:
 
 test-tcsh:
 	tcsh -e ./test/direnv-test.tcsh
+	tcsh    ./test/direnv-test-lax.tcsh
 
 test-zsh:
 	zsh ./test/direnv-test.zsh

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -145,8 +145,7 @@ test-tcsh:
 	tcsh -e ./test/direnv-test.tcsh
 
 test-zsh:
-	# Currently missing
-	#zsh ./test/direnv-test.zsh
+	zsh ./test/direnv-test.zsh
 
 ############################################################################
 # Installation

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -142,8 +142,7 @@ test-fish:
 	fish ./test/direnv-test.fish
 
 test-tcsh:
-	# Currently broken
-	#tcsh -e ./test/direnv-test.tcsh
+	tcsh -e ./test/direnv-test.tcsh
 
 test-zsh:
 	# Currently missing

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ eval "$(direnv hook zsh)"
 Add the following line at the end of the `~/.config/fish/config.fish` file:
 
 ```fish
-eval (direnv hook fish)
+direnv hook fish | source
 ```
 
 ### TCSH

--- a/cmd_apply_dump.go
+++ b/cmd_apply_dump.go
@@ -33,7 +33,7 @@ var CmdApplyDump = &Cmd{
 
 		diff := env.Diff(dumpedEnv)
 
-		exports := diff.ToShell(BASH)
+		exports := diff.ToShell(BASH, nil)
 
 		_, err = fmt.Println(exports)
 		if err != nil {

--- a/cmd_dotenv.go
+++ b/cmd_dotenv.go
@@ -45,7 +45,7 @@ var CmdDotEnv = &Cmd{
 			return err
 		}
 
-		str := env.ToShell(shell)
+		str := env.ToShell(shell, nil)
 		fmt.Println(str)
 
 		return

--- a/cmd_gzenv.go
+++ b/cmd_gzenv.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"github.com/direnv/direnv/gzenv"
+)
+
+// `direnv gzenv encode <str>` and `direnv gzenv decode <str>`
+var CmdGzEnv = &Cmd{
+	Name:    "gzenv",
+	Desc:    "Encode and decode a string using the gzenv format",
+	Args:    []string{"<encode|decode>", "STRING", "[...STRING]"},
+	Private: true,
+	Fn: func(env Env, args []string) (err error) {
+		if len(args) < 2 || (args[1] != "encode" && args[1] != "decode") {
+			return fmt.Errorf("missing <encode|decode> action")
+		}
+
+		encode := args[1] == "encode"
+
+		for _, s := range args[2:] {
+			var r interface{}
+			if encode {
+				r = gzenv.Marshal(s)
+			} else {
+				err := gzenv.Unmarshal(s, &r)
+				if err != nil {
+					fmt.Println("Bad encoding: ", s)
+					continue
+				}
+			}
+			fmt.Println(r)
+		}
+
+		return
+	},
+}

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -43,7 +43,7 @@ func watchCommand(env Env, args []string) (err error) {
 	e := make(ShellExport)
 	e.Add(DIRENV_WATCHES, watches.Marshal())
 
-	fmt.Printf(shell.Export(e))
+	fmt.Printf(shell.Export(e, nil))
 
 	return
 }

--- a/commands.go
+++ b/commands.go
@@ -30,6 +30,7 @@ func init() {
 		CmdExec,
 		CmdExpandPath,
 		CmdExport,
+		CmdGzEnv,
 		CmdHelp,
 		CmdHook,
 		CmdPrune,

--- a/env.go
+++ b/env.go
@@ -84,3 +84,18 @@ func (e Env) Fetch(key, def string) string {
 	}
 	return v
 }
+
+func (env Env) GetShellQuotes() (quotes ShellQuotes) {
+	quotes = make(map[Shell]string)
+	for key, value := range env {
+		target := strings.TrimPrefix(key, "DIRENV_QUOTE_")
+		if target == key {
+			continue
+		}
+		shell := DetectShell(target)
+		if shell != nil {
+			quotes[shell] = value
+		}
+	}
+	return
+}

--- a/env.go
+++ b/env.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -31,6 +32,11 @@ func (env Env) CleanContext() {
 	delete(env, DIRENV_DIR)
 	delete(env, DIRENV_WATCHES)
 	delete(env, DIRENV_DIFF)
+	for key := range env {
+		if _, err := TryGetShellTarget("DIRENV_ON_UNLOAD_", key); err == nil {
+			delete(env, key)
+		}
+	}
 }
 
 func LoadEnv(gzenvStr string) (env Env, err error) {
@@ -59,14 +65,14 @@ func (env Env) ToGoEnv() []string {
 	return goEnv
 }
 
-func (env Env) ToShell(shell Shell) string {
+func (env Env) ToShell(shell Shell, quotes ShellQuotes) string {
 	e := make(ShellExport)
 
 	for key, value := range env {
 		e.Add(key, value)
 	}
 
-	return shell.Export(e)
+	return shell.Export(e, quotes)
 }
 
 func (env Env) Serialize() string {
@@ -86,16 +92,40 @@ func (e Env) Fetch(key, def string) string {
 }
 
 func (env Env) GetShellQuotes() (quotes ShellQuotes) {
-	quotes = make(map[Shell]string)
+	quotes = make(ShellQuotes)
 	for key, value := range env {
-		target := strings.TrimPrefix(key, "DIRENV_QUOTE_")
-		if target == key {
-			continue
+		if shell, err := TryGetShellTarget("DIRENV_QUOTE_", key); err == nil {
+			quotes[shell] = []string{value}
 		}
-		shell := DetectShell(target)
-		if shell != nil {
-			quotes[shell] = value
+	}
+	return
+}
+
+func (env Env) GetOnUnloadShellQuotes() (quotes ShellQuotes) {
+	quotes = make(ShellQuotes)
+	for key, value := range env {
+		if shell, err := TryGetShellTarget("DIRENV_ON_UNLOAD_", key); err == nil {
+			qs := strings.Split(value, ",")
+			for i, encodedQuote := range qs {
+				var unencodedQuote string
+				gzenv.Unmarshal(encodedQuote, &unencodedQuote)
+				qs[i] = unencodedQuote
+			}
+			quotes[shell] = qs
 		}
+	}
+	return
+}
+
+func TryGetShellTarget(prefix, s string) (shell Shell, err error) {
+	target := strings.TrimPrefix(s, prefix)
+	if target == s {
+		err = fmt.Errorf("TryGetShellTarget() - %q is not prefix of %q", prefix, s)
+		return
+	}
+	shell = DetectShell(target)
+	if shell == nil {
+		err = fmt.Errorf("TryGetShellTarget() - unknown shell %q", target)
 	}
 	return
 }

--- a/env_diff.go
+++ b/env_diff.go
@@ -75,7 +75,7 @@ func (self *EnvDiff) Any() bool {
 	return len(self.Prev) > 0 || len(self.Next) > 0
 }
 
-func (self *EnvDiff) ToShell(shell Shell) string {
+func (self *EnvDiff) ToShell(shell Shell, quotes ShellQuotes) string {
 	e := make(ShellExport)
 
 	for key := range self.Prev {
@@ -89,7 +89,7 @@ func (self *EnvDiff) ToShell(shell Shell) string {
 		e.Add(key, value)
 	}
 
-	return shell.Export(e)
+	return shell.Export(e, quotes)
 }
 
 func (self *EnvDiff) Patch(env Env) (newEnv Env) {
@@ -128,6 +128,9 @@ func IgnoredEnv(key string) bool {
 		return true
 	}
 	if strings.HasPrefix(key, "DIRENV_QUOTE_") {
+		return true
+	}
+	if strings.HasPrefix(key, "DIRENV_ON_UNLOAD_") {
 		return true
 	}
 	_, found := IGNORED_KEYS[key]

--- a/env_diff.go
+++ b/env_diff.go
@@ -127,6 +127,9 @@ func IgnoredEnv(key string) bool {
 	if strings.HasPrefix(key, "BASH_FUNC_") {
 		return true
 	}
+	if strings.HasPrefix(key, "DIRENV_QUOTE_") {
+		return true
+	}
 	_, found := IGNORED_KEYS[key]
 	return found
 }

--- a/shell.go
+++ b/shell.go
@@ -9,7 +9,7 @@ import (
  */
 type Shell interface {
 	Hook() (string, error)
-	Export(e ShellExport) string
+	Export(e ShellExport, q ShellQuotes) string
 	Dump(env Env) string
 }
 
@@ -25,7 +25,18 @@ func (e ShellExport) Remove(key string) {
 }
 
 // Shell-specific commands
-type ShellQuotes map[Shell]string
+type ShellQuotes map[Shell][]string
+
+func MergeShellQuotes(l, r ShellQuotes) (merged ShellQuotes) {
+	merged = make(ShellQuotes)
+	for k, v := range l {
+		merged[k] = v
+	}
+	for k, v := range r {
+		merged[k] = append(merged[k], v...)
+	}
+	return
+}
 
 func DetectShell(target string) Shell {
 	target = filepath.Base(target)

--- a/shell.go
+++ b/shell.go
@@ -24,6 +24,9 @@ func (e ShellExport) Remove(key string) {
 	e[key] = nil
 }
 
+// Shell-specific commands
+type ShellQuotes map[Shell]string
+
 func DetectShell(target string) Shell {
 	target = filepath.Base(target)
 	// $0 starts with "-"

--- a/shell_bash.go
+++ b/shell_bash.go
@@ -1,6 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type bash struct{}
 
@@ -21,7 +24,7 @@ func (sh bash) Hook() (string, error) {
 	return BASH_HOOK, nil
 }
 
-func (sh bash) Export(e ShellExport) (out string) {
+func (sh bash) Export(e ShellExport, q ShellQuotes) (out string) {
 	for key, value := range e {
 		if value == nil {
 			out += sh.unset(key)
@@ -29,6 +32,9 @@ func (sh bash) Export(e ShellExport) (out string) {
 			out += sh.export(key, *value)
 		}
 	}
+	// For quotes, prefer "\n" over ";", since it will handle comments and
+	// empty commands better
+	out += strings.Join(q[sh], "\n")
 	return out
 }
 

--- a/shell_elvish.go
+++ b/shell_elvish.go
@@ -28,7 +28,7 @@ func (elvish) Hook() (string, error) {
 `, nil
 }
 
-func (sh elvish) Export(e ShellExport) string {
+func (sh elvish) Export(e ShellExport, q ShellQuotes) string {
 	buf := new(bytes.Buffer)
 	err := json.NewEncoder(buf).Encode(e)
 	if err != nil {

--- a/shell_fish.go
+++ b/shell_fish.go
@@ -11,7 +11,7 @@ var FISH Shell = fish{}
 
 const FISH_HOOK = `
 function __direnv_export_eval --on-event fish_prompt;
-	eval ("{{.SelfPath}}" export fish);
+	"{{.SelfPath}}" export fish | source;
 end
 `
 

--- a/shell_fish.go
+++ b/shell_fish.go
@@ -19,7 +19,7 @@ func (sh fish) Hook() (string, error) {
 	return FISH_HOOK, nil
 }
 
-func (sh fish) Export(e ShellExport) (out string) {
+func (sh fish) Export(e ShellExport, q ShellQuotes) (out string) {
 	for key, value := range e {
 		if value == nil {
 			out += sh.unset(key)
@@ -27,6 +27,9 @@ func (sh fish) Export(e ShellExport) (out string) {
 			out += sh.export(key, *value)
 		}
 	}
+	// For quotes, prefer "\n" over ";", since it will handle comments and
+	// empty commands better
+	out += strings.Join(q[sh], "\n")
 	return out
 }
 

--- a/shell_gzenv.go
+++ b/shell_gzenv.go
@@ -15,7 +15,7 @@ func (s gzenvShell) Hook() (string, error) {
 	return "", errors.New("the gzenv shell doesn't support hooking")
 }
 
-func (s gzenvShell) Export(e ShellExport) string {
+func (s gzenvShell) Export(e ShellExport, q ShellQuotes) string {
 	return gzenv.Marshal(e)
 }
 

--- a/shell_json.go
+++ b/shell_json.go
@@ -14,7 +14,7 @@ func (sh jsonShell) Hook() (string, error) {
 	return "", errors.New("this feature is not supported")
 }
 
-func (sh jsonShell) Export(e ShellExport) string {
+func (sh jsonShell) Export(e ShellExport, q ShellQuotes) string {
 	out, err := json.MarshalIndent(e, "", "  ")
 	if err != nil {
 		// Should never happen

--- a/shell_tcsh.go
+++ b/shell_tcsh.go
@@ -21,9 +21,8 @@ func (sh tcsh) Export(e ShellExport, q ShellQuotes) (out string) {
 			out += sh.export(key, *value)
 		}
 	}
-	// For quotes, prefer "\n" over ";", since it will handle comments and
-	// empty commands better
-	out += strings.Join(q[sh], "\n")
+	// For quotes, use ";\n" since it will handle comments and empty commands better
+	out += strings.Join(q[sh], ";\n")
 	return out
 }
 

--- a/shell_tcsh.go
+++ b/shell_tcsh.go
@@ -13,7 +13,7 @@ func (sh tcsh) Hook() (string, error) {
 	return "alias precmd 'eval `{{.SelfPath}} export tcsh`'", nil
 }
 
-func (sh tcsh) Export(e ShellExport) (out string) {
+func (sh tcsh) Export(e ShellExport, q ShellQuotes) (out string) {
 	for key, value := range e {
 		if value == nil {
 			out += sh.unset(key)
@@ -21,6 +21,9 @@ func (sh tcsh) Export(e ShellExport) (out string) {
 			out += sh.export(key, *value)
 		}
 	}
+	// For quotes, prefer "\n" over ";", since it will handle comments and
+	// empty commands better
+	out += strings.Join(q[sh], "\n")
 	return out
 }
 

--- a/shell_vim.go
+++ b/shell_vim.go
@@ -13,7 +13,7 @@ func (sh vim) Hook() (string, error) {
 	return "", errors.New("this feature is not supported. Install the direnv.vim plugin instead.")
 }
 
-func (sh vim) Export(e ShellExport) (out string) {
+func (sh vim) Export(e ShellExport, q ShellQuotes) (out string) {
 	for key, value := range e {
 		if value == nil {
 			out += sh.unset(key)
@@ -21,6 +21,7 @@ func (sh vim) Export(e ShellExport) (out string) {
 			out += sh.export(key, *value)
 		}
 	}
+	out += strings.Join(q[sh], "\n")
 	return out
 }
 

--- a/shell_zsh.go
+++ b/shell_zsh.go
@@ -1,5 +1,7 @@
 package main
 
+import "strings"
+
 // ZSH is a singleton instance of ZSH_T
 type zsh struct{}
 
@@ -19,7 +21,7 @@ func (sh zsh) Hook() (string, error) {
 	return ZSH_HOOK, nil
 }
 
-func (sh zsh) Export(e ShellExport) (out string) {
+func (sh zsh) Export(e ShellExport, q ShellQuotes) (out string) {
 	for key, value := range e {
 		if value == nil {
 			out += sh.unset(key)
@@ -27,6 +29,9 @@ func (sh zsh) Export(e ShellExport) (out string) {
 			out += sh.export(key, *value)
 		}
 	}
+	// For quotes, prefer "\n" over ";", since it will handle comments and
+	// empty commands better
+	out += strings.Join(q[sh], "\n")
 	return out
 }
 

--- a/stdlib.go
+++ b/stdlib.go
@@ -724,7 +724,8 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"\n" +
 	"quote bash \"unset DIRENV_ON_UNLOAD_bash\"\n" +
 	"quote zsh  \"unset DIRENV_ON_UNLOAD_zsh\"\n" +
-	"quote fish  \"set -e DIRENV_ON_UNLOAD_fish\"\n" +
+	"quote fish \"set -e DIRENV_ON_UNLOAD_fish\"\n" +
+	"quote tcsh \"unsetenv DIRENV_ON_UNLOAD_tcsh\"\n" +
 	"\n" +
 	"# Usage: shell_specific <shell> <make_on_unload> <on_load>\n" +
 	"#\n" +
@@ -754,9 +755,17 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"          \"$on_load\"\n" +
 	"      quote \"$shell\" \"$cmd\"\n" +
 	"      ;;\n" +
+	"    tcsh)\n" +
+	"      printf -v cmd \\\n" +
+	"        \"set DIRENV_UNLOAD=\\`%s\\`;if ( \\$?DIRENV_ON_UNLOAD_tcsh == 0 ) setenv DIRENV_ON_UNLOAD_tcsh;setenv DIRENV_ON_UNLOAD_tcsh \\$DIRENV_ON_UNLOAD_tcsh\\`%s gzenv encode \\\"\\$DIRENV_UNLOAD\\\"\\`,;unset DIRENV_UNLOAD;%s\" \\\n" +
+	"          \"$make_on_unload\" \\\n" +
+	"          \"$direnv\" \\\n" +
+	"          \"$on_load\"\n" +
+	"      quote \"$shell\" \"$cmd\"\n" +
+	"      ;;\n" +
 	"    *)\n" +
-	"       log_error \"shell_specific: '$shell' unsupported.\"\n" +
-	"       ;;\n" +
+	"      log_error \"shell_specific: '$shell' unsupported.\"\n" +
+	"      ;;\n" +
 	"  esac\n" +
 	"}\n" +
 	"\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -722,6 +722,34 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"  export \"${quote_var?}\"\n" +
 	"}\n" +
 	"\n" +
+	"quote bash \"unset DIRENV_ON_UNLOAD_bash\"\n" +
+	"quote zsh  \"unset DIRENV_ON_UNLOAD_zsh\"\n" +
+	"\n" +
+	"# Usage: shell_specific <shell> <make_on_unload> <on_load>\n" +
+	"#\n" +
+	"# Creates a shell-specific action. Both `make_on_unload` and `on_load`\n" +
+	"# are strings with code to be executed on the given host shell.\n" +
+	"# `make_on_unload` will be executed first; it is expected to output\n" +
+	"# shell-specific code to \"undo\" the effects of `on_load`.\n" +
+	"shell_specific() {\n" +
+	"  local shell=$1\n" +
+	"  local make_on_unload=$2\n" +
+	"  local on_load=$3\n" +
+	"  local on_unload_var=\"DIRENV_ON_UNLOAD_${shell}\"\n" +
+	"  case \"$shell\" in\n" +
+	"    bash | zsh)\n" +
+	"       printf -v cmd \\\n" +
+	"         \"export ${on_unload_var}; ${on_unload_var}+=\\$($direnv gzenv encode \\\"\\$(%s)\\\"),;%s\" \\\n" +
+	"         \"$make_on_unload\" \\\n" +
+	"         \"$on_load\"\n" +
+	"       quote \"$shell\" \"$cmd\"\n" +
+	"       ;;\n" +
+	"    *)\n" +
+	"       log_error \"shell_specific: '$shell' unsupported.\"\n" +
+	"       ;;\n" +
+	"  esac\n" +
+	"}\n" +
+	"\n" +
 	"## Load the global ~/.direnvrc if present\n" +
 	"if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/direnv/direnvrc ]]; then\n" +
 	"  # shellcheck disable=SC1090\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -706,6 +706,22 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"  eval \"$(guix environment \"$@\" --search-paths)\"\n" +
 	"}\n" +
 	"\n" +
+	"# Usage: quote <shell> [...]\n" +
+	"#\n" +
+	"# Example:\n" +
+	"#\n" +
+	"#  quote zsh alias foo=bar\n" +
+	"#\n" +
+	"# This will add `alias foo=bar;` to the output of `direnv export zsh`\n" +
+	"quote() {\n" +
+	"  local shell=$1\n" +
+	"  local quote_var=\"DIRENV_QUOTE_${shell}\"\n" +
+	"  shift\n" +
+	"  local previous=${!quote_var:-''}\n" +
+	"  printf -v \"${quote_var}\" \"%s%s;\" \"$previous\" \"$*\"\n" +
+	"  export \"${quote_var?}\"\n" +
+	"}\n" +
+	"\n" +
 	"## Load the global ~/.direnvrc if present\n" +
 	"if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/direnv/direnvrc ]]; then\n" +
 	"  # shellcheck disable=SC1090\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -724,6 +724,7 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"\n" +
 	"quote bash \"unset DIRENV_ON_UNLOAD_bash\"\n" +
 	"quote zsh  \"unset DIRENV_ON_UNLOAD_zsh\"\n" +
+	"quote fish  \"set -e DIRENV_ON_UNLOAD_fish\"\n" +
 	"\n" +
 	"# Usage: shell_specific <shell> <make_on_unload> <on_load>\n" +
 	"#\n" +
@@ -735,15 +736,24 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"  local shell=$1\n" +
 	"  local make_on_unload=$2\n" +
 	"  local on_load=$3\n" +
-	"  local on_unload_var=\"DIRENV_ON_UNLOAD_${shell}\"\n" +
 	"  case \"$shell\" in\n" +
 	"    bash | zsh)\n" +
+	"       local on_unload_var=\"DIRENV_ON_UNLOAD_${shell}\"\n" +
 	"       printf -v cmd \\\n" +
 	"         \"export ${on_unload_var}; ${on_unload_var}+=\\$($direnv gzenv encode \\\"\\$(%s)\\\"),;%s\" \\\n" +
 	"         \"$make_on_unload\" \\\n" +
 	"         \"$on_load\"\n" +
 	"       quote \"$shell\" \"$cmd\"\n" +
 	"       ;;\n" +
+	"    fish)\n" +
+	"      # shellcheck disable=SC2016\n" +
+	"      printf -v cmd \\\n" +
+	"        '%s | read -lz DIRENV_UNLOAD; set DIRENV_UNLOAD (%s gzenv encode \"$DIRENV_UNLOAD\"); set -x -g DIRENV_ON_UNLOAD_fish \"$DIRENV_ON_UNLOAD_fish$DIRENV_UNLOAD,\";set -e DIRENV_UNLOAD;%s' \\\n" +
+	"          \"$make_on_unload\" \\\n" +
+	"          \"$direnv\" \\\n" +
+	"          \"$on_load\"\n" +
+	"      quote \"$shell\" \"$cmd\"\n" +
+	"      ;;\n" +
 	"    *)\n" +
 	"       log_error \"shell_specific: '$shell' unsupported.\"\n" +
 	"       ;;\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -704,6 +704,22 @@ use_guix() {
   eval "$(guix environment "$@" --search-paths)"
 }
 
+# Usage: quote <shell> [...]
+#
+# Example:
+#
+#  quote zsh alias foo=bar
+#
+# This will add `alias foo=bar;` to the output of `direnv export zsh`
+quote() {
+  local shell=$1
+  local quote_var="DIRENV_QUOTE_${shell}"
+  shift
+  local previous=${!quote_var:-''}
+  printf -v "${quote_var}" "%s%s;" "$previous" "$*"
+  export "${quote_var?}"
+}
+
 ## Load the global ~/.direnvrc if present
 if [[ -f ${XDG_CONFIG_HOME:-$HOME/.config}/direnv/direnvrc ]]; then
   # shellcheck disable=SC1090

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -723,6 +723,7 @@ quote() {
 quote bash "unset DIRENV_ON_UNLOAD_bash"
 quote zsh  "unset DIRENV_ON_UNLOAD_zsh"
 quote fish "set -e DIRENV_ON_UNLOAD_fish"
+quote tcsh "unsetenv DIRENV_ON_UNLOAD_tcsh"
 
 # Usage: shell_specific <shell> <make_on_unload> <on_load>
 #
@@ -752,9 +753,17 @@ shell_specific() {
           "$on_load"
       quote "$shell" "$cmd"
       ;;
+    tcsh)
+      printf -v cmd \
+        "set DIRENV_UNLOAD=\`%s\`;if ( \$?DIRENV_ON_UNLOAD_tcsh == 0 ) setenv DIRENV_ON_UNLOAD_tcsh;setenv DIRENV_ON_UNLOAD_tcsh \$DIRENV_ON_UNLOAD_tcsh\`%s gzenv encode \"\$DIRENV_UNLOAD\"\`,;unset DIRENV_UNLOAD;%s" \
+          "$make_on_unload" \
+          "$direnv" \
+          "$on_load"
+      quote "$shell" "$cmd"
+      ;;
     *)
-       log_error "shell_specific: '$shell' unsupported."
-       ;;
+      log_error "shell_specific: '$shell' unsupported."
+      ;;
   esac
 }
 

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -24,7 +24,7 @@ mkdir -p ${XDG_CONFIG_HOME}/direnv
 touch ${XDG_CONFIG_HOME}/direnv/direnvrc
 
 direnv_eval() {
-  eval `direnv export $TARGET_SHELL`
+  eval "$(direnv export $TARGET_SHELL)"
 }
 
 test_start() {

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -228,6 +228,34 @@ test_start "shell-specific"
 
  test_stop
 
+test_start "alias"
+  unalias foo 2>/dev/null || true
+  alias bar='original bar'
+
+  direnv_eval
+
+  # NB. zsh and bash differ in that bash will prepend an "alias " to
+  # the output of `alias foo`
+  test_eq "$(alias foo | sed -e 's/^alias //')" "foo='ls -l'"
+  test_eq "$(alias bar | sed -e 's/^alias //')" "bar='ls -t'"
+
+  cd nested
+  direnv allow
+  direnv_eval
+  test_eq "$(alias foo 2>/dev/null || true)" ""
+  test_eq "$(alias bar | sed -e 's/^alias //')" "bar='df -h'"
+
+  cd ..
+  direnv_eval
+  test_eq "$(alias foo | sed -e 's/^alias //')" "foo='ls -l'"
+  test_eq "$(alias bar | sed -e 's/^alias //')" "bar='ls -t'"
+
+  cd ..
+  direnv_eval
+  test_eq "$(alias foo 2>/dev/null || true)" ""
+  test_eq "$(alias bar | sed -e 's/^alias //')" "bar='original bar'"
+test_stop
+
 # Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file
 # BUG: foo/bar is resolved in the .envrc execution context and so can't find
 #      the .envrc file.

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -1,0 +1,195 @@
+# Test script for Bourne-shell extensions. Set TARGET_SHELL
+# to the shell to be tested (bash, zsh, etc) before sourcing it.
+if [[ -z "TARGET_SHELL" ]]; then
+  echo "TARGET_SHELL variable not set"
+  exit 1
+fi
+
+set -e
+
+cd `dirname $0`
+TEST_DIR=$PWD
+export PATH=`dirname $TEST_DIR`:$PATH
+
+# Reset the direnv loading if any
+export DIRENV_CONFIG=$PWD
+unset DIRENV_BASH
+unset DIRENV_DIR
+unset DIRENV_MTIME
+unset DIRENV_WATCHES
+unset DIRENV_DIFF
+
+export XDG_CONFIG_HOME=${TEST_DIR}/config
+mkdir -p ${XDG_CONFIG_HOME}/direnv
+touch ${XDG_CONFIG_HOME}/direnv/direnvrc
+
+direnv_eval() {
+  eval `direnv export $TARGET_SHELL`
+}
+
+test_start() {
+  cd "$TEST_DIR/scenarios/$1"
+  direnv allow
+  if [[ "$DIRENV_DEBUG" == "1" ]]; then
+    echo
+  fi
+  echo "## Testing $1 ##"
+  if [[ "$DIRENV_DEBUG" == "1" ]]; then
+    echo
+  fi
+}
+
+test_stop() {
+  cd $TEST_DIR
+  direnv_eval
+}
+
+test_eq() {
+  if [[ "$1" != "$2" ]]; then
+    echo "FAILED: '$1' == '$2'"
+    exit 1
+  fi
+}
+
+test_neq() {
+  if [[ "$1" == "$2" ]]; then
+    echo "FAILED: '$1' != '$2'"
+    exit 1
+  fi
+}
+
+### RUN ###
+
+direnv allow || true
+direnv_eval
+
+test_start base
+  echo "Setting up"
+  direnv_eval
+  test_eq "$HELLO" "world"
+
+  WATCHES=$DIRENV_WATCHES
+
+  echo "Reloading (should be no-op)"
+  direnv_eval
+  test_eq "$WATCHES" "$DIRENV_WATCHES"
+
+  sleep 1
+
+  echo "Updating envrc and reloading (should reload)"
+  touch .envrc
+  direnv_eval
+  test_neq "$WATCHES" "$DIRENV_WATCHES"
+
+  echo "Leaving dir (should clear env set by dir's envrc)"
+  cd ..
+  direnv_eval
+  echo "${HELLO}"
+  test -z "${HELLO}"
+test_stop
+
+test_start inherit
+  cp ../base/.envrc ../inherited/.envrc
+  direnv_eval
+  echo "HELLO should be world:" $HELLO
+
+  sleep 1
+  echo "export HELLO=goodbye" > ../inherited/.envrc
+  direnv_eval
+  test_eq "$HELLO" "goodbye"
+test_stop
+
+test_start "ruby-layout"
+  direnv_eval
+  test_neq "$GEM_HOME" ""
+test_stop
+
+# Make sure directories with spaces are fine
+test_start "space dir"
+  direnv_eval
+  test_eq "$SPACE_DIR" "true"
+test_stop
+
+test_start "child-env"
+  direnv_eval
+  test_eq "$PARENT_PRE" "1"
+  test_eq "$CHILD" "1"
+  test_eq "$PARENT_POST" "1"
+  test -z "$REMOVE_ME"
+test_stop
+
+test_start "special-vars"
+  export DIRENV_BASH=`command -v bash`
+  export DIRENV_CONFIG=foobar
+  direnv_eval || true
+  test -n "$DIRENV_BASH"
+  test_eq "$DIRENV_CONFIG" "foobar"
+  unset DIRENV_BASH
+  unset DIRENV_CONFIG
+test_stop
+
+test_start "dump"
+  direnv_eval
+  test_eq "$LS_COLORS" "*.ogg=38;5;45:*.wav=38;5;45"
+  test_eq "$THREE_BACKSLASHES" '\\\'
+  test_eq "$LESSOPEN" "||/usr/bin/lesspipe.sh %s"
+test_stop
+
+test_start "empty-var"
+  direnv_eval
+  test_neq "${FOO-unset}" "unset"
+  test_eq "${FOO}" ""
+test_stop
+
+test_start "empty-var-unset"
+  export FOO=""
+  direnv_eval
+  test_eq "${FOO-unset}" "unset"
+  unset FOO
+test_stop
+
+test_start "in-envrc"
+  direnv_eval
+  set +e
+  ./test-in-envrc
+  es=$?
+  set -e
+  test_eq "$es" "1"
+test_stop
+
+test_start "missing-file-source-env"
+  direnv_eval
+test_stop
+
+test_start "symlink-changed"
+  # when using a symlink, reload if the symlink changes, or if the
+  # target file changes.
+  ln -fs ./state-A ./symlink
+  direnv_eval
+  test_eq "${STATE}" "A"
+  sleep 1
+
+  ln -fs ./state-B ./symlink
+  direnv_eval
+  test_eq "${STATE}" "B"
+test_stop
+
+# Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file
+# BUG: foo/bar is resolved in the .envrc execution context and so can't find
+#      the .envrc file.
+#
+# Apparently, the CHDIR syscall does that so I don't know how to work around
+# the issue.
+#
+# test_start "symlink-bug"
+#   cd foo/bar
+#   direnv_eval
+# test_stop
+
+# Pending: test that the mtime is looked on the original file
+# test_start "utils"
+#   LINK_TIME=`direnv file-mtime link-to-somefile`
+#   touch somefile
+#   NEW_LINK_TIME=`direnv file-mtime link-to-somefile`
+#   test "$LINK_TIME" = "$NEW_LINK_TIME"
+# test_stop

--- a/test/direnv-test-lax.tcsh
+++ b/test/direnv-test-lax.tcsh
@@ -1,0 +1,55 @@
+#!/usr/bin/env tcsh
+
+# NB. This script is ran without the -e option. That means that it will not
+# stop automatically on errors. We need this when testing tcsh-specific code
+# that need to perform tests at runtime (e.g. using grep), since any non-0 exit
+# code will cause the script to fail (can't be escaped, disabled, etc.).
+#
+# If possible, place new tests in direnv-test.tcsh
+
+cd `dirname $0`
+setenv TEST_DIR $PWD
+setenv PATH `dirname $TEST_DIR`:$PATH
+
+# Reset the direnv loading if any
+setenv DIRENV_CONFIG $PWD
+unsetenv DIRENV_BASH
+unsetenv DIRENV_DIR
+unsetenv DIRENV_MTIME
+unsetenv DIRENV_WATCHES
+unsetenv DIRENV_DIFF
+unsetenv DIRENV_ON_UNLOAD_tcsh
+
+alias direnv_eval 'eval `direnv export tcsh` || exit 1'
+
+cd $TEST_DIR/scenarios/"alias"
+  direnv allow
+  echo "Testing alias"
+
+  unalias foo
+  alias bar 'original bar'
+
+  direnv_eval
+
+  test "`alias foo`" = "ls -l" || exit 1
+  test "`alias bar`" = "ls -t" || exit 1
+
+  cd nested
+  direnv allow
+  direnv_eval
+
+  test -z "`alias foo`" || exit 1
+  test "`alias bar`" = "df -h" || exit 1
+
+  cd ..
+  direnv_eval
+
+  test "`alias foo`" = "ls -l" || exit 1
+  test "`alias bar`" = "ls -t" || exit 1
+
+  cd ..
+  direnv_eval
+
+  test -z "`alias foo`" || exit 1
+  test "`alias bar`" = "original bar" || exit 1
+cd $TEST_DIR ; direnv_eval

--- a/test/direnv-test.fish
+++ b/test/direnv-test.fish
@@ -25,7 +25,7 @@ set -e DIRENV_DIFF
 
 function direnv_eval
   #direnv export fish # for debugging
-  eval (direnv export fish)
+  direnv export fish | source
 end
 
 function test_start -a name

--- a/test/direnv-test.fish
+++ b/test/direnv-test.fish
@@ -135,3 +135,57 @@ test_start "shell-specific"
   eq (math "$FOO_1" + 100) "$FOO"
   eq (math "$FOOX_1" + 100) "$FOOX"
 test_stop
+
+test_start "alias"
+  functions -e foo
+  alias bar='original bar'
+
+  function expected_alias_def --argument-names name val
+    printf "function %s --description 'alias %s=%s'\n\t%s \$argv;\nend" "$name" "$name" "$val" "$val"
+  end
+
+  direnv_eval
+
+  set expected_foo (expected_alias_def foo "ls -l")
+  set actual_foo (functions foo | grep -v '^#')
+  eq "$expected_foo" "$actual_foo"
+
+  set expected_bar (expected_alias_def bar "ls -t")
+  set actual_bar (functions bar | grep -v '^#')
+  eq "$expected_bar" "$actual_bar"
+
+  cd nested
+  direnv allow
+  direnv_eval
+
+  set expected_foo ""
+  set actual_foo (functions foo; or true)
+  eq "$expected_foo"  "$actual_foo"
+
+  set expected_bar (expected_alias_def bar "df -h")
+  set actual_bar (functions bar | grep -v '^#')
+  eq "$expected_bar" "$actual_bar"
+
+  cd ..
+  direnv_eval
+
+  set expected_foo (expected_alias_def foo "ls -l")
+  set actual_foo (functions foo | grep -v '^#')
+  eq "$expected_foo" "$actual_foo"
+
+  set expected_bar (expected_alias_def bar "ls -t")
+  set actual_bar (functions bar | grep -v '^#')
+  eq "$expected_bar" "$actual_bar"
+
+  cd ..
+  direnv_eval
+
+  set expected_foo ""
+  set actual_foo (functions foo; or true)
+  eq "$expected_foo" "$actual_foo"
+
+  set expected_bar (expected_alias_def bar "original bar")
+  set actual_bar (functions bar | grep -v '^#')
+  eq "$expected_bar" "$actual_bar"
+
+test_stop

--- a/test/direnv-test.fish
+++ b/test/direnv-test.fish
@@ -11,6 +11,30 @@ function eq --argument-names a b
 	end
 end
 
+function ge --argument-names a b
+   if not test (count $argv) = 2
+    echo "Error: " (count $argv) " arguments passed to `ge`: $argv"
+    exit 1
+   end
+
+   if not test $a -ge $b
+    printf "Error: expected %s > %s\n" "$a" "$b"
+    exit 1
+   end
+end
+
+function lt --argument-names a b
+   if not test (count $argv) = 2
+    echo "Error: " (count $argv) " arguments passed to `lt`: $argv"
+    exit 1
+   end
+
+   if not test $a -lt $b
+    printf "Error: expected %s < %s\n" "$a" "$b"
+    exit 1
+   end
+end
+
 cd (dirname (status -f))
 set TEST_DIR $PWD
 set -gx PATH (dirname $TEST_DIR) $PATH
@@ -22,6 +46,7 @@ set -e DIRENV_DIR
 set -e DIRENV_WATCHES
 set -e DIRENV_MTIME
 set -e DIRENV_DIFF
+set -e DIRENV_ON_UNLOAD_fish
 
 function direnv_eval
   #direnv export fish # for debugging
@@ -51,4 +76,62 @@ test_start dump
 	eq "$LS_COLORS" "*.ogg=38;5;45:*.wav=38;5;45"
 	eq "$LESSOPEN" "||/usr/bin/lesspipe.sh %s"
 	eq "$THREE_BACKSLASHES" "\\\\\\"
+test_stop
+
+test_start "shell-specific"
+  set -e BAR
+  set -e FOO
+  set -e FOOX
+  set -e FOO_OR_NAN
+  set -e FOOX_OR_NAN
+  set -e BAR_OR_NAN
+
+  set -x TARGET_SHELL fish
+
+  direnv_eval
+  # FOO=x; ON UNLOAD WILL RUN FOO=x + 100
+  # export FOOX=y; ON UNLOAD WILL RUN FOOX=FOOX + 100
+
+  ge "$FOO" 0
+  ge "$FOOX" 0
+  ge "$BAR" 0
+
+  set FOO_0 "$FOO"
+  set FOOX_0 "$FOOX"
+  set BAR_0 "$BAR"
+
+  direnv allow nested/.envrc
+  cd nested
+  direnv_eval
+  # Set by nested/.envrc
+  eq "NaN" "$FOO_OR_NAN"
+  eq "NaN" "$BAR_OR_NAN"
+  eq "$FOOX_0" "$FOOX_OR_NAN"  # unlike BAR
+
+  # Set by unload action of ./.envrc
+  eq (math "$FOO_0" + 100) "$FOO"
+
+  # Set by combination of action in nested/..envrc and unload of .envrc
+  eq (math \($FOOX_0 + 100\) '%' 3) "$FOOX"
+
+  cd ..
+  direnv_eval
+
+  # New random values
+  ge "$FOO" 0
+  ge "$BAR" 0
+
+  # Random value overrides the FOOX + 1000 on_unload from nested/.envrc
+  lt "$FOOX" 100
+
+  set FOO_1 "$FOO"
+  set BAR_1 "$BAR"
+  set FOOX_1 "$FOOX"
+
+  cd ..
+  direnv_eval
+
+  # Unload actions from .envrc
+  eq (math "$FOO_1" + 100) "$FOO"
+  eq (math "$FOOX_1" + 100) "$FOOX"
 test_stop

--- a/test/direnv-test.fish
+++ b/test/direnv-test.fish
@@ -46,7 +46,7 @@ direnv allow
 direnv_eval
 
 test_start dump
-	set -ex LS_COLORS
+	set -e LS_COLORS
 	direnv_eval
 	eq "$LS_COLORS" "*.ogg=38;5;45:*.wav=38;5;45"
 	eq "$LESSOPEN" "||/usr/bin/lesspipe.sh %s"

--- a/test/direnv-test.tcsh
+++ b/test/direnv-test.tcsh
@@ -12,9 +12,6 @@ unsetenv DIRENV_MTIME
 unsetenv DIRENV_WATCHES
 unsetenv DIRENV_DIFF
 
-# direnv_eval() {
-#   eval `direnv export bash`
-# }
 alias direnv_eval 'eval `direnv export tcsh`'
 
 # test_start() {
@@ -51,15 +48,20 @@ cd $TEST_DIR/scenarios/base
 
   cd ..
   direnv_eval
-  echo "$?HELLO"
   test 0 -eq "$?HELLO"
 cd $TEST_DIR ; direnv_eval
 
 cd $TEST_DIR/scenarios/inherit
+  cp ../base/.envrc ../inherited/.envrc
   direnv allow
   echo "Testing inherit"
   direnv_eval
   test "$HELLO" = "world"
+
+  sleep 1
+  echo "export HELLO=goodbye" > ../inherited/.envrc
+  direnv_eval
+  test "$HELLO" = "goodbye"
 cd $TEST_DIR ; direnv_eval
 
 cd $TEST_DIR/scenarios/ruby-layout

--- a/test/direnv-test.tcsh
+++ b/test/direnv-test.tcsh
@@ -11,6 +11,7 @@ unsetenv DIRENV_DIR
 unsetenv DIRENV_MTIME
 unsetenv DIRENV_WATCHES
 unsetenv DIRENV_DIFF
+unsetenv DIRENV_ON_UNLOAD_tcsh
 
 alias direnv_eval 'eval `direnv export tcsh`'
 
@@ -116,6 +117,74 @@ cd $TEST_DIR/scenarios/"empty-var-unset"
   direnv_eval
   test "$?FOO" -eq '0'
   unsetenv FOO
+cd $TEST_DIR ; direnv_eval
+
+cd $TEST_DIR/scenarios/"shell-specific"
+  direnv allow
+  echo "Testing shell-specific"
+
+  unsetenv BAR
+  unsetenv FOO
+  unsetenv FOOX
+  unsetenv FOO_OR_NAN
+  unsetenv FOOX_OR_NAN
+  unsetenv BAR_OR_NAN
+
+  setenv TARGET_SHELL tcsh
+
+  direnv_eval
+  # FOO=x; ON UNLOAD WILL RUN FOO=x + 100
+  # export FOOX=y; ON UNLOAD WILL RUN FOOX=FOOX + 100
+
+  test "$FOO" -ge 0
+  test "$FOOX" -ge 0
+  test "$BAR" -ge 0
+
+  set FOO_0=$FOO
+  set FOOX_0=$FOOX
+  set BAR_0=$BAR
+
+  direnv allow nested/.envrc
+  cd nested
+  direnv_eval
+  # Set by nested/.envrc
+  test "$FOO_OR_NAN" = "NaN"
+  test "$BAR_OR_NAN" = "NaN"
+  test "$FOOX_OR_NAN" = $FOOX_0  # unlike BAR
+
+  # NB. In what follows, the usages of expr are safe since the result != 0.
+  # Othewise, `expr` will exit with status 1, which is normal, not an error, but
+  # this will break since tcsh is ran with -e.
+
+  # Set by unload action of ./.envrc
+  test "$FOO" -eq `expr "$FOO_0" + 100`
+
+  # Set by combination of action in nested/..envrc and unload of .envrc
+  # The +1 on both sides of -eq is to ensure the exist status of expr is 0
+  test `expr $FOOX + 1` -eq `expr \( "$FOOX_0" + 100 \) % 3 + 1`
+
+  cd ..
+  direnv_eval
+
+  # New random values
+  test "$FOO" -ge 0
+  test "$BAR" -ge 0
+
+  # Random value overrides the FOOX + 1000 on_unload from nested/.envrc
+  test "$FOOX" -ge 0
+  test "$FOOX" -lt 100
+
+  set FOO_1=$FOO
+  set BAR_1=$BAR
+  set FOOX_1=$FOOX
+
+  cd ..
+  direnv_eval
+
+  # Unload actions from .envrc
+  test "$FOO" -eq `expr "$FOO_1" + 100`
+  test "$FOOX" -eq `expr "$FOOX_1" + 100`
+
 cd $TEST_DIR ; direnv_eval
 
 # Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file

--- a/test/direnv-test.zsh
+++ b/test/direnv-test.zsh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
-export TARGET_SHELL=bash
+#!/usr/bin/env zsh
+export TARGET_SHELL=zsh
 source "$(dirname $0)/direnv-test-common.sh"

--- a/test/scenarios/alias/.envrc
+++ b/test/scenarios/alias/.envrc
@@ -1,0 +1,2 @@
+use aliases
+alias foo='ls -l' bar='ls -t'

--- a/test/scenarios/alias/nested/.envrc
+++ b/test/scenarios/alias/nested/.envrc
@@ -1,0 +1,2 @@
+use aliases
+alias bar='df -h'

--- a/test/scenarios/missing-file-source-env/.envrc
+++ b/test/scenarios/missing-file-source-env/.envrc
@@ -1,1 +1,1 @@
-source_env "$(mktemp -d -t $RANDOM)"
+source_env "$(mktemp -d -t $RANDOM.XXXXXXXX)"

--- a/test/scenarios/shell-specific/.envrc
+++ b/test/scenarios/shell-specific/.envrc
@@ -1,7 +1,10 @@
 # Set FOO to a random value x, don't export it. On unload, set to x+100
 val_loaded=$((RANDOM%100))
 val_unloaded=$(($val_loaded + 100))
-shell_specific "$TARGET_SHELL" "echo FOO=$val_unloaded" "FOO=$val_loaded"
+
+shell_specific bash "echo FOO=$val_unloaded"          "FOO=$val_loaded"
+shell_specific zsh  "echo FOO=$val_unloaded"          "FOO=$val_loaded"
+shell_specific fish "echo 'set -g FOO $val_unloaded'" "set -g FOO $val_loaded"
 
 # Set BAR as a random value and export it in the normal way.
 export BAR=$((RANDOM%100))
@@ -10,4 +13,6 @@ export BAR=$((RANDOM%100))
 # NB. The value of FOOX will be observable from the next rc that is loaded.
 val_loaded=$((RANDOM%100))
 
-shell_specific "$TARGET_SHELL" "echo 'FOOX=\$((FOOX+100))'" "export FOOX=$val_loaded"
+shell_specific bash "echo 'FOOX=\$((FOOX+100))'"                "export FOOX=$val_loaded"
+shell_specific zsh  "echo 'FOOX=\$((FOOX+100))'"                "export FOOX=$val_loaded"
+shell_specific fish "echo 'set -x -g FOOX (math \$FOOX + 100)'" "set -x -g FOOX $val_loaded"

--- a/test/scenarios/shell-specific/.envrc
+++ b/test/scenarios/shell-specific/.envrc
@@ -5,6 +5,7 @@ val_unloaded=$(($val_loaded + 100))
 shell_specific bash "echo FOO=$val_unloaded"          "FOO=$val_loaded"
 shell_specific zsh  "echo FOO=$val_unloaded"          "FOO=$val_loaded"
 shell_specific fish "echo 'set -g FOO $val_unloaded'" "set -g FOO $val_loaded"
+shell_specific tcsh "echo 'set FOO=$val_unloaded'"    "set FOO=$val_loaded"
 
 # Set BAR as a random value and export it in the normal way.
 export BAR=$((RANDOM%100))
@@ -16,3 +17,4 @@ val_loaded=$((RANDOM%100))
 shell_specific bash "echo 'FOOX=\$((FOOX+100))'"                "export FOOX=$val_loaded"
 shell_specific zsh  "echo 'FOOX=\$((FOOX+100))'"                "export FOOX=$val_loaded"
 shell_specific fish "echo 'set -x -g FOOX (math \$FOOX + 100)'" "set -x -g FOOX $val_loaded"
+shell_specific tcsh "echo '@ FOOX_ = \$FOOX + 100; setenv FOOX \$FOOX_'" "setenv FOOX $val_loaded"

--- a/test/scenarios/shell-specific/.envrc
+++ b/test/scenarios/shell-specific/.envrc
@@ -1,0 +1,13 @@
+# Set FOO to a random value x, don't export it. On unload, set to x+100
+val_loaded=$((RANDOM%100))
+val_unloaded=$(($val_loaded + 100))
+shell_specific "$TARGET_SHELL" "echo FOO=$val_unloaded" "FOO=$val_loaded"
+
+# Set BAR as a random value and export it in the normal way.
+export BAR=$((RANDOM%100))
+
+# Set FOOX to a random value, and't export it. On unload add 100 to its current value
+# NB. The value of FOOX will be observable from the next rc that is loaded.
+val_loaded=$((RANDOM%100))
+
+shell_specific "$TARGET_SHELL" "echo 'FOOX=\$((FOOX+100))'" "export FOOX=$val_loaded"

--- a/test/scenarios/shell-specific/nested/.envrc
+++ b/test/scenarios/shell-specific/nested/.envrc
@@ -1,0 +1,7 @@
+export FOO_OR_NAN=${FOO:-NaN}
+export FOOX_OR_NAN=${FOOX:-NaN}
+
+export BAR_OR_NAN=${BAR:-NaN}
+
+val_loaded=$((FOOX%3))
+shell_specific "$TARGET_SHELL" "echo 'FOOX=\$((FOOX+1000))'" 'FOOX=$((FOOX%3))'

--- a/test/scenarios/shell-specific/nested/.envrc
+++ b/test/scenarios/shell-specific/nested/.envrc
@@ -7,3 +7,6 @@ val_loaded=$((FOOX%3))
 shell_specific bash "echo 'FOOX=\$((FOOX+1000))'"         'FOOX=$((FOOX%3))'
 shell_specific zsh  "echo 'FOOX=\$((FOOX+1000))'"         'FOOX=$((FOOX%3))'
 shell_specific fish 'echo "set FOOX (math $FOOX + 1000)"' 'set FOOX (math $FOOX "%" 3)'
+shell_specific tcsh \
+  "echo '@ FOOX_ = \$FOOX + 1000; setenv FOOX \$FOOX_'" \
+  '@ FOOX_ = $FOOX % 3; setenv FOOX $FOOX_'

--- a/test/scenarios/shell-specific/nested/.envrc
+++ b/test/scenarios/shell-specific/nested/.envrc
@@ -4,4 +4,6 @@ export FOOX_OR_NAN=${FOOX:-NaN}
 export BAR_OR_NAN=${BAR:-NaN}
 
 val_loaded=$((FOOX%3))
-shell_specific "$TARGET_SHELL" "echo 'FOOX=\$((FOOX+1000))'" 'FOOX=$((FOOX%3))'
+shell_specific bash "echo 'FOOX=\$((FOOX+1000))'"         'FOOX=$((FOOX%3))'
+shell_specific zsh  "echo 'FOOX=\$((FOOX+1000))'"         'FOOX=$((FOOX%3))'
+shell_specific fish 'echo "set FOOX (math $FOOX + 1000)"' 'set FOOX (math $FOOX "%" 3)'


### PR DESCRIPTION
This implements a mechanism to send shell-specific code to the host shell from the `.envrc` file, along with a simple protocol to register clean-up actions to be performed when unloading the environment. The supported shells at the moment are `bash`, `zsh`, `tcsh` and `fish` (`elvish` is missing only because it doesn't have an `eval` function, or I couldn't find it).

Based on this, we implement the exporting of aliases from `.envrc`  (#73). The same mechanism should let us support loading/unloading shell-completion scripts (#443) and, more in general, run arbitrary commands on entry/exit of the environment.

The core of `direnv` was left mostly unaffected; this is a rundown of the changes:

  * The first 2 commits add tests for `tcsh` and `zsh`, so that we can then test the new functionality on all shells. For the latter, we can simply share the test script with `bash` as long as we stay within bourne shell code. 

  * The next 3 commits fix minor issues in tests.

  * Next, we introduce a `quote` command to the stdlib. Intuitively, `quote fish foo bar` will add `foo bar;` to the output of `direnv export fish`, etc. This works by accumulating the quotes for shell `xxsh` on the `DIRENV_QUOTES_xxsh` environment variable (excluded from `DIRENV_DIFF`).

  * `quote` is a low-level operation: it will only send commands when the environment is loaded. The next 5 commits add the higher-level `shell_specific` command to the stdlib that allows one to also register clean up actions. If an `.envrc` file were to include the following:
    ```bash
    shell_specific zsh "echo 'rm -f foo'" "touch foo"
    ```
    Then loading the environment with `direnv export zsh` would have, conceptually, the following additional effect:
    ```bash
    export DIRENV_ON_UNLOAD_zsh=$(echo 'rm -f foo')
    touch foo
    ```
     `DIRENV_ON_UNLOAD_zsh` is honoured by `direnv export zsh` when unloading the environment, which would then include the extra effect:
    ```bash
    rm -f foo
    ```
  * The second argument to `shell_specific` is conceptually a function computing the clean-up action. In the above example, we use `echo 'rm -f foo'` as a constant function that always returns `rm -f foo`. For a more realistic example, when implementing aliases for `bash`, we can exploit that `alias foo` outputs the full definition of `foo` (including the `alias` keyword) and use something like:
    ```bash
    shell_specific bash 'alias foo || echo unalias foo' 'alias foo=ls -lt'
    ```  
  * In reality, `DIRENV_ON_UNLOAD_xxsh` is a comma-separated list of gzenv-encoded quotes. In order to be able to add elements to this list from the envrc, we added a `direnv gzenv [encode|decode]` private command.

  * The last commit adds a `use_aliases` function to the stdlib, so that the alias-exposing functionality becomes opt-in. The usage is:
    ```bash
    alias hello=world  # hello will not be exported

    use aliases
    alias foo=bar  # foo will be exported
    ```