### PR TITLE
Corrects reverse patching when using exec cmd.

### DIFF
--- a/cmd_exec.go
+++ b/cmd_exec.go
@@ -51,7 +51,7 @@ var CmdExec = &Cmd{
 
 		// Restore pristine environment if needed
 		if backupDiff, err = config.EnvDiff(); err == nil {
-			backupDiff.Reverse().Patch(env)
+			env = backupDiff.Reverse().Patch(env)
 		}
 		env.CleanContext()
 


### PR DESCRIPTION
The cleaned-up environment created after reverse patching the current environment was not used for the exec cmd.