### PR TITLE
Fix bash hook

### DIFF
--- a/shell_bash.go
+++ b/shell_bash.go
@@ -12,7 +12,9 @@ _direnv_hook() {
   eval "$("{{.SelfPath}}" export bash)";
   return $previous_exit_status;
 };
-if ! [[ "$PROMPT_COMMAND" =~ _direnv_hook ]]; then
+if [[ -z "$PROMPT_COMMAND" ]]; then
+  PROMPT_COMMAND="_direnv_hook"
+elif ! [[ "$PROMPT_COMMAND" =~ _direnv_hook ]]; then
   PROMPT_COMMAND="_direnv_hook;$PROMPT_COMMAND"
 fi
 `

--- a/shell_bash.go
+++ b/shell_bash.go
@@ -12,10 +12,8 @@ _direnv_hook() {
   eval "$("{{.SelfPath}}" export bash)";
   return $previous_exit_status;
 };
-if [[ -z "$PROMPT_COMMAND" ]]; then
-  PROMPT_COMMAND="_direnv_hook"
-elif ! [[ "$PROMPT_COMMAND" =~ _direnv_hook ]]; then
-  PROMPT_COMMAND="_direnv_hook;$PROMPT_COMMAND"
+if ! [[ "${PROMPT_COMMAND:-}" =~ _direnv_hook ]]; then
+  PROMPT_COMMAND="_direnv_hook${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 fi
 `
 


### PR DESCRIPTION
When the direnv is the first element added to PROMPT_COMMAND
(PROMPT_COMMAND is empty) the trailing semicolon character is unneeded,
and, in some cases, breaks the prompt due an invalid syntax when more
elements are added.