### PR TITLE
fix arity mismatch error

### DIFF
--- a/shell_elvish.go
+++ b/shell_elvish.go
@@ -13,12 +13,15 @@ func (elvish) Hook() (string, error) {
 	return `## hook for direnv
 @edit:before-readline = $@edit:before-readline {
 	try {
-		m = ("{{.SelfPath}}" export elvish | from-json)
-		keys $m | each [k]{
-			if (==s $k 'null') {
-				unset-env $k
-			} else {
-				set-env $k $m[$k]
+		m = [("{{.SelfPath}}" export elvish | from-json)]
+		if (> (count $m) 1) {
+			m = (explode $m)
+			keys $m | each [k]{
+				if (==s $k 'null') {
+					unset-env $k
+				} else {
+					set-env $k $m[$k]
+				}
 			}
 		}
 	} except e {


### PR DESCRIPTION
this also remove `echo $e` which is annoying when there is no .envrc in current or parent folders