### PR TITLE
config: direnv warn timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ jobs:
       - template: ci/build-steps.yml
 
   - job: Release
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     pool:
       vmImage: 'ubuntu-16.04'
     steps:

--- a/cmd_allow.go
+++ b/cmd_allow.go
@@ -10,9 +10,8 @@ var CmdAllow = &Cmd{
 	Name: "allow",
 	Desc: "Grants direnv to load the given .envrc",
 	Args: []string{"[PATH_TO_RC]"},
-	Fn: func(env Env, args []string) (err error) {
+	Action: actionWithConfig(func(env Env, args []string, config *Config) (err error) {
 		var rcPath string
-		var config *Config
 		if len(args) > 1 {
 			rcPath = args[1]
 		} else {
@@ -21,14 +20,10 @@ var CmdAllow = &Cmd{
 			}
 		}
 
-		if config, err = LoadConfig(env); err != nil {
-			return
-		}
-
 		rc := FindRC(rcPath, config)
 		if rc == nil {
 			return fmt.Errorf(".envrc file not found")
 		}
 		return rc.Allow()
-	},
+	}),
 }

--- a/cmd_apply_dump.go
+++ b/cmd_apply_dump.go
@@ -11,7 +11,7 @@ var CmdApplyDump = &Cmd{
 	Desc:    "Accepts a filename containing `direnv dump` output and generates a series of bash export statements to apply the given env",
 	Args:    []string{"FILE"},
 	Private: true,
-	Fn: func(env Env, args []string) (err error) {
+	Action: actionSimple(func(env Env, args []string) (err error) {
 		if len(args) < 2 {
 			return fmt.Errorf("Not enough arguments")
 		}
@@ -41,5 +41,5 @@ var CmdApplyDump = &Cmd{
 		}
 
 		return
-	},
+	}),
 }

--- a/cmd_current.go
+++ b/cmd_current.go
@@ -9,7 +9,7 @@ var CmdCurrent = &Cmd{
 	Desc:    "Reports whether direnv's view of a file is current (or stale)",
 	Args:    []string{"PATH"},
 	Private: true,
-	Fn:      currentCommandFn,
+	Action:  actionSimple(currentCommandFn),
 }
 
 func currentCommandFn(env Env, args []string) (err error) {

--- a/cmd_deny.go
+++ b/cmd_deny.go
@@ -10,9 +10,8 @@ var CmdDeny = &Cmd{
 	Name: "deny",
 	Desc: "Revokes the authorization of a given .envrc",
 	Args: []string{"[PATH_TO_RC]"},
-	Fn: func(env Env, args []string) (err error) {
+	Action: actionWithConfig(func(env Env, args []string, config *Config) (err error) {
 		var rcPath string
-		var config *Config
 
 		if len(args) > 1 {
 			rcPath = args[1]
@@ -22,14 +21,10 @@ var CmdDeny = &Cmd{
 			}
 		}
 
-		if config, err = LoadConfig(env); err != nil {
-			return
-		}
-
 		rc := FindRC(rcPath, config)
 		if rc == nil {
 			return fmt.Errorf(".envrc file not found")
 		}
 		return rc.Deny()
-	},
+	}),
 }

--- a/cmd_dotenv.go
+++ b/cmd_dotenv.go
@@ -17,7 +17,7 @@ var CmdDotEnv = &Cmd{
 	Desc:    "Transforms a .env file to evaluatable `export KEY=PAIR` statements",
 	Args:    []string{"[SHELL]", "[PATH_TO_DOTENV]"},
 	Private: true,
-	Fn: func(env Env, args []string) (err error) {
+	Action: actionSimple(func(env Env, args []string) (err error) {
 		var shell Shell
 		var target string
 
@@ -49,5 +49,5 @@ var CmdDotEnv = &Cmd{
 		fmt.Println(str)
 
 		return
-	},
+	}),
 }

--- a/cmd_dump.go
+++ b/cmd_dump.go
@@ -8,7 +8,7 @@ var CmdDump = &Cmd{
 	Desc:    "Used to export the inner bash state at the end of execution",
 	Args:    []string{"[SHELL]"},
 	Private: true,
-	Fn: func(env Env, args []string) (err error) {
+	Action: actionSimple(func(env Env, args []string) (err error) {
 		target := "gzenv"
 
 		if len(args) > 1 {
@@ -23,5 +23,5 @@ var CmdDump = &Cmd{
 		fmt.Println(shell.Dump(env))
 
 		return
-	},
+	}),
 }

--- a/cmd_edit.go
+++ b/cmd_edit.go
@@ -14,20 +14,14 @@ var CmdEdit = &Cmd{
 	Name: "edit",
 	Desc: `Opens PATH_TO_RC or the current .envrc into an $EDITOR and allow
   the file to be loaded afterwards.`,
-	Args:   []string{"[PATH_TO_RC]"},
-	NoWait: true,
-	Fn: func(env Env, args []string) (err error) {
-		var config *Config
+	Args: []string{"[PATH_TO_RC]"},
+	Action: actionWithConfig(func(env Env, args []string, config *Config) (err error) {
 		var rcPath string
 		var times *FileTimes
 		var foundRC *RC
 
 		defer log.SetPrefix(log.Prefix())
 		log.SetPrefix(log.Prefix() + "cmd_edit: ")
-
-		if config, err = LoadConfig(env); err != nil {
-			return
-		}
 
 		foundRC = config.FindRC()
 		if foundRC != nil {
@@ -78,7 +72,7 @@ var CmdEdit = &Cmd{
 		}
 
 		return
-	},
+	}),
 }
 
 // Utils

--- a/cmd_exec.go
+++ b/cmd_exec.go
@@ -12,10 +12,9 @@ var CmdExec = &Cmd{
 	Name: "exec",
 	Desc: "Executes a command after loading the first .envrc found in DIR",
 	Args: []string{"[DIR]", "COMMAND", "[...ARGS]"},
-	Fn: func(env Env, args []string) (err error) {
+	Action: actionWithConfig(func(env Env, args []string, config *Config) (err error) {
 		var (
 			backupDiff *EnvDiff
-			config     *Config
 			newEnv     Env
 			rcPath     string
 			command    string
@@ -43,10 +42,6 @@ var CmdExec = &Cmd{
 			args = args[1:]
 		}
 
-		if config, err = LoadConfig(env); err != nil {
-			return
-		}
-
 		rc := FindRC(rcPath, config)
 
 		// Restore pristine environment if needed
@@ -71,5 +66,5 @@ var CmdExec = &Cmd{
 
 		err = syscall.Exec(command, args, newEnv.ToGoEnv())
 		return
-	},
+	}),
 }

--- a/cmd_expand_path.go
+++ b/cmd_expand_path.go
@@ -20,7 +20,7 @@ var CmdExpandPath = &Cmd{
 	Desc:    "Transforms a PATH to an absolute path to REL_TO or $PWD",
 	Args:    []string{"PATH", "[REL_TO]"},
 	Private: true,
-	Fn: func(env Env, args []string) (err error) {
+	Action: actionSimple(func(env Env, args []string) (err error) {
 		var path string
 
 		flagset := flag.NewFlagSet(args[0], flag.ExitOnError)
@@ -50,5 +50,5 @@ var CmdExpandPath = &Cmd{
 		_, err = fmt.Println(path)
 
 		return
-	},
+	}),
 }

--- a/cmd_help.go
+++ b/cmd_help.go
@@ -11,7 +11,7 @@ var CmdHelp = &Cmd{
 	Desc:    "shows this help",
 	Args:    []string{"[SHOW_PRIVATE]"},
 	Aliases: []string{"--help"},
-	Fn: func(env Env, args []string) (err error) {
+	Action: actionSimple(func(env Env, args []string) (err error) {
 		var showPrivate = len(args) > 1
 		fmt.Printf(`direnv v%s
 Usage: direnv COMMAND [...ARGS]
@@ -37,5 +37,5 @@ Available commands
 			fmt.Println("* = private commands")
 		}
 		return
-	},
+	}),
 }

--- a/cmd_hook.go
+++ b/cmd_hook.go
@@ -17,7 +17,7 @@ var CmdHook = &Cmd{
 	Name: "hook",
 	Desc: "Used to setup the shell hook",
 	Args: []string{"SHELL"},
-	Fn: func(env Env, args []string) (err error) {
+	Action: actionSimple(func(env Env, args []string) (err error) {
 		var target string
 
 		if len(args) > 1 {
@@ -52,5 +52,5 @@ var CmdHook = &Cmd{
 		}
 
 		return
-	},
+	}),
 }

--- a/cmd_prune.go
+++ b/cmd_prune.go
@@ -10,16 +10,11 @@ import (
 var CmdPrune = &Cmd{
 	Name: "prune",
 	Desc: "removes old allowed files",
-	Fn: func(env Env, args []string) (err error) {
-		var config *Config
+	Action: actionWithConfig(func(env Env, args []string, config *Config) (err error) {
 		var dir *os.File
 		var fi os.FileInfo
 		var dir_list []string
 		var envrc []byte
-
-		if config, err = LoadConfig(env); err != nil {
-			return err
-		}
 
 		allowed := config.AllowDir()
 		if dir, err = os.Open(allowed); err != nil {
@@ -55,5 +50,5 @@ var CmdPrune = &Cmd{
 
 		}
 		return nil
-	},
+	}),
 }

--- a/cmd_reload.go
+++ b/cmd_reload.go
@@ -7,17 +7,12 @@ import (
 var CmdReload = &Cmd{
 	Name: "reload",
 	Desc: "triggers an env reload",
-	Fn: func(env Env, args []string) error {
-		config, err := LoadConfig(env)
-		if err != nil {
-			return err
-		}
-
+	Action: actionWithConfig(func(env Env, args []string, config *Config) error {
 		foundRC := config.FindRC()
 		if foundRC == nil {
 			return fmt.Errorf(".envrc not found")
 		}
 
 		return foundRC.Touch()
-	},
+	}),
 }

--- a/cmd_show_dump.go
+++ b/cmd_show_dump.go
@@ -14,7 +14,7 @@ var CmdShowDump = &Cmd{
 	Desc:    "Show the data inside of a dump for debugging purposes",
 	Args:    []string{"DUMP"},
 	Private: true,
-	Fn: func(env Env, args []string) (err error) {
+	Action: actionSimple(func(env Env, args []string) (err error) {
 		if len(args) < 2 {
 			return fmt.Errorf("Missing DUMP argument")
 		}
@@ -28,5 +28,5 @@ var CmdShowDump = &Cmd{
 		e := json.NewEncoder(os.Stdout)
 		e.SetIndent("", "  ")
 		return e.Encode(f)
-	},
+	}),
 }

--- a/cmd_status.go
+++ b/cmd_status.go
@@ -8,12 +8,7 @@ import (
 var CmdStatus = &Cmd{
 	Name: "status",
 	Desc: "prints some debug status information",
-	Fn: func(env Env, args []string) error {
-		config, err := LoadConfig(env)
-		if err != nil {
-			return err
-		}
-
+	Action: actionWithConfig(func(env Env, args []string, config *Config) error {
 		fmt.Println("direnv exec path", config.SelfPath)
 		fmt.Println("DIRENV_CONFIG", config.ConfDir)
 		fmt.Println("DIRENV_BASH", config.BashPath)
@@ -34,7 +29,7 @@ var CmdStatus = &Cmd{
 		}
 
 		return nil
-	},
+	}),
 }
 
 func formatRC(desc string, rc *RC) {

--- a/cmd_stdlib.go
+++ b/cmd_stdlib.go
@@ -9,13 +9,8 @@ import (
 var CmdStdlib = &Cmd{
 	Name: "stdlib",
 	Desc: "Displays the stdlib available in the .envrc execution context",
-	Fn: func(env Env, args []string) (err error) {
-		var config *Config
-		if config, err = LoadConfig(env); err != nil {
-			return
-		}
-
+	Action: actionWithConfig(func(env Env, args []string, config *Config) error {
 		fmt.Println(strings.Replace(STDLIB, "$(command -v direnv)", config.SelfPath, 1))
-		return
-	},
+		return nil
+	}),
 }

--- a/cmd_version.go
+++ b/cmd_version.go
@@ -8,8 +8,8 @@ var CmdVersion = &Cmd{
 	Name:    "version",
 	Desc:    "prints the version",
 	Aliases: []string{"--version"},
-	Fn: func(env Env, args []string) error {
+	Action: actionSimple(func(env Env, args []string) error {
 		fmt.Println(VERSION)
 		return nil
-	},
+	}),
 }

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -7,7 +7,7 @@ var CmdWatch = &Cmd{
 	Desc:    "Adds a path to the list that direnv watches for changes",
 	Args:    []string{"[SHELL]", "PATH"},
 	Private: false,
-	Fn:      watchCommand,
+	Action:  actionSimple(watchCommand),
 }
 
 func watchCommand(env Env, args []string) (err error) {

--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -34,6 +34,16 @@ key = "value"
 .PP
 The following sections are supported:
 
+.SH \fB\fCwarn\_timeout\fR
+.PP
+Specify how long to wait before warning the user that the command is taking
+too long to execute. Defaults to "5s".
+
+.PP
+A duration string is a possibly signed sequence of decimal numbers, each with
+optional fraction and a unit suffix, such as "300ms", "\-1.5h" or "2h45m".
+Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
 .SH \fB\fCwhitelist\fR
 .PP
 Specifying whitelist directives marks specific directory hierarchies or specific directories as "trusted" \-\- direnv will evaluate any matching .envrc files regardless of whether they have been specifically allowed. \fBThis feature should be used with great care\fP, as anyone with the ability to write files to that directory (including collaborators on VCS repositories) will be able to execute arbitrary code on your computer.

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -30,6 +30,15 @@ key = "value"
 
 The following sections are supported:
 
+## `warn_timeout`
+
+Specify how long to wait before warning the user that the command is taking
+too long to execute. Defaults to "5s".
+
+A duration string is a possibly signed sequence of decimal numbers, each with
+optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
+Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". 
+
 ## `whitelist`
 
 Specifying whitelist directives marks specific directory hierarchies or specific directories as "trusted" -- direnv will evaluate any matching .envrc files regardless of whether they have been specifically allowed. **This feature should be used with great care**, as anyone with the ability to write files to that directory (including collaborators on VCS repositories) will be able to execute arbitrary code on your computer.


### PR DESCRIPTION
timeouts are only applied on cmd_export

this sets the duration after which direnv should warn the user that

configuring direnv from environment variables should be deprecated