### PR TITLE
direnv exec: DIR is always necessary

### DIFF
--- a/cmd_exec.go
+++ b/cmd_exec.go
@@ -7,11 +7,11 @@ import (
 	"syscall"
 )
 
-// `direnv exec [DIR] <COMMAND> ...`
+// `direnv exec DIR <COMMAND> ...`
 var CmdExec = &Cmd{
 	Name: "exec",
 	Desc: "Executes a command after loading the first .envrc found in DIR",
-	Args: []string{"[DIR]", "COMMAND", "[...ARGS]"},
+	Args: []string{"DIR", "COMMAND", "[...ARGS]"},
 	Action: actionWithConfig(func(env Env, args []string, config *Config) (err error) {
 		var (
 			backupDiff *EnvDiff


### PR DESCRIPTION
```
$ direnv exec bash -c "true"
direnv: error stat bash: no such file or directory
$ direnv exec bash
direnv: error stat bash: no such file or directory
```

Meaning leaving out the DIR argument was never really an option.