### PR TITLE
Add use_vim to source local vimrc

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -432,6 +432,15 @@ use node 4.2.2
 .fi
 .RE
 
+.SS \fB\fCuse vim [<vimrc\_file>]\fR
+.PP
+Prepends the specified vim script (or .vimrc.local by default) to the
+\fB\fCDIRENV\_EXTRA\_VIMRC\fR environment variable.
+
+.PP
+This variable is understood by the direnv/direnv.vim extension. When found,
+it will source it after opening files in the directory.
+
 .SS \fB\fCwatch\_file <path> [<path> ...]\fR
 .PP
 Adds each file to direnv's watch\-list. If the file changes direnv will reload the environment on the next prompt.

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -303,6 +303,14 @@ Example (.envrc):
     set -e
     use node 4.2.2
 
+### `use vim [<vimrc_file>]`
+
+Prepends the specified vim script (or .vimrc.local by default) to the
+`DIRENV_EXTRA_VIMRC` environment variable.
+
+This variable is understood by the direnv/direnv.vim extension. When found,
+it will source it after opening files in the directory.
+
 ### `watch_file <path> [<path> ...]`
 
 Adds each file to direnv's watch-list. If the file changes direnv will reload the environment on the next prompt.

--- a/stdlib.go
+++ b/stdlib.go
@@ -964,6 +964,18 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  eval \"$(guix environment \"$@\" --search-paths)\"\n" +
 	"}\n" +
 	"\n" +
+	"# Usage: use_vim [<vimrc_file>]\n" +
+	"#\n" +
+	"# Prepends the specified vim script (or .vimrc.local by default) to the\n" +
+	"# `DIRENV_EXTRA_VIMRC` environment variable.\n" +
+	"#\n" +
+	"# This variable is understood by the direnv/direnv.vim extension. When found,\n" +
+	"# it will source it after opening files in the directory.\n" +
+	"use_vim() {\n" +
+	"  local extra_vimrc=${1:-.vimrc.local}\n" +
+	"  path_add DIRENV_EXTRA_VIMRC \"$extra_vimrc\"\n" +
+	"}\n" +
+	"\n" +
 	"# Usage: direnv_version <version_at_least>\n" +
 	"#\n" +
 	"# Checks that the direnv version is at least old as <version_at_least>.\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -961,6 +961,18 @@ use_guix() {
   eval "$(guix environment "$@" --search-paths)"
 }
 
+# Usage: use_vim [<vimrc_file>]
+#
+# Prepends the specified vim script (or .vimrc.local by default) to the
+# `DIRENV_EXTRA_VIMRC` environment variable.
+#
+# This variable is understood by the direnv/direnv.vim extension. When found,
+# it will source it after opening files in the directory.
+use_vim() {
+  local extra_vimrc=${1:-.vimrc.local}
+  path_add DIRENV_EXTRA_VIMRC "$extra_vimrc"
+}
+
 # Usage: direnv_version <version_at_least>
 #
 # Checks that the direnv version is at least old as <version_at_least>.


### PR DESCRIPTION
I want to load `.vimrc.local` stored on the project top dir every time Vim runs `direnv` command. There is a similar solution already on [Wiki][wiki], but this has some problems.

[wiki]: https://github.com/direnv/direnv/wiki/Vim

This solution expects `direnv` sets env variables before Vim starts to open files. Vim starts, then it reads `$EXTRA_VIM` in sourcing `~/.vimrc`, and loads the local `.vimrc`.

But with this, Vim cannot load the local `.vimrc` in the following cases.

1. When another `DirChanged` event occurs. (that is, `direnv` command runs again)
2. When another buffer window opens.
    - This is needed because the local vimrc's often set buffer-specified settings. (`setlocal`, `b:foo_var`, and so on)

To solve this, Vim should source the local `.vimrc`'s just after `direnv` command finishes. In addition to that, Vim also should source on the `BufEnter` event.

This PR and [another one on direnv.vim][pr] make this available.

[pr]: https://github.com/direnv/direnv.vim/pull/17

1. call func in `.envrc`

    ```sh
    use vim
    ```

2. write local `.vimrc.local` (use this name to avoid loading the main `~/.vimrc`)

    ```vim
    " write buffer-local settings
    let b:foo_bar = 1
    setlocal expandtab
    setlocal shiftwidth=4
    ```

3. and you see settings enabled after opening files on the directory.
