### PR TITLE
rename the configuration to direnv.toml

### DIFF
--- a/config.go
+++ b/config.go
@@ -73,12 +73,21 @@ func LoadConfig(env Env) (config *Config, err error) {
 	config.WhitelistPrefix = make([]string, 0)
 	config.WhitelistExact = make(map[string]bool)
 
-	// Load the config.toml
+	// Load the TOML config
+	config.TomlPath = filepath.Join(config.ConfDir, "direnv.toml")
+	if _, statErr := os.Stat(config.TomlPath); statErr != nil {
+		config.TomlPath = ""
+	}
+
 	config.TomlPath = filepath.Join(config.ConfDir, "config.toml")
-	if _, statErr := os.Stat(config.TomlPath); statErr == nil {
+	if _, statErr := os.Stat(config.TomlPath); statErr != nil {
+		config.TomlPath = ""
+	}
+
+	if config.TomlPath != "" {
 		var tomlConf tomlConfig
 		if _, err = toml.DecodeFile(config.TomlPath, &tomlConf); err != nil {
-			err = fmt.Errorf("LoadConfig() failed to parse config.toml: %q", err)
+			err = fmt.Errorf("LoadConfig() failed to parse %s: %q", config.TomlPath, err)
 			return
 		}
 

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -9,7 +9,7 @@ direnv.toml - the direnv configuration file
 DESCRIPTION
 -----------
 
-A configuration file in [TOML](https://github.com/toml-lang/toml) format to specify a variety of configuration options for direnv. Resides at CONFIGURATION_DIR/config.toml. For many users, this will be located at $HOME/.config/direnv/config.toml.
+A configuration file in [TOML](https://github.com/toml-lang/toml) format to specify a variety of configuration options for direnv. Resides at CONFIGURATION_DIR/direnv.toml. For many users, this will be located at $HOME/.config/direnv/direnv.toml.
 
 FORMAT
 ------


### PR DESCRIPTION
it was confusing that the man page and configuration name weren't the
same. Keep config.toml around for back-compate.

see also https://github.com/direnv/direnv/issues/180#issuecomment-494287848