### PR TITLE
[use_nix] Passing arguments to use_nix should not determine whether files are watched

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -685,12 +685,19 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"#\n" +
 	"# Load environment variables from `nix-shell`.\n" +
 	"# If you have a `default.nix` or `shell.nix` these will be\n" +
-	"# used by default, but you can also specify packages directly\n" +
-	"# (e.g `use nix -p ocaml`).\n" +
+	"# used by default unless NIX_NO_WATCH_DEFAULT is set to \"true\"\n" +
+	"# or by passing `--no-watch-default` as first parameter\n" +
+	"# Arguments are passed to nix-shell as is, eg. you can specify packages directly\n" +
+	"# using `use nix -p ocaml`.\n" +
 	"#\n" +
 	"use_nix() {\n" +
+	"  local NIX_NO_WATCH_DEFAULT=\"${NIX_NO_WATCH_DEFAULT:-false}\"\n" +
+	"  if [[ \"${1:-}\" == \"--no-watch-default\" ]]; then\n" +
+	"    NIX_NO_WATCH_DEFAULT=\"true\"\n" +
+	"    shift\n" +
+	"  fi\n" +
 	"  direnv_load nix-shell --show-trace \"$@\" --run \"$(join_args \"$direnv\" dump)\"\n" +
-	"  if [[ $# == 0 ]]; then\n" +
+	"  if [[ \"${NO_WATCH_DEFAULT:-false}\" == \"false\" ]]; then\n" +
 	"    watch_file default.nix\n" +
 	"    watch_file shell.nix\n" +
 	"  fi\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -683,12 +683,19 @@ use_node() {
 #
 # Load environment variables from `nix-shell`.
 # If you have a `default.nix` or `shell.nix` these will be
-# used by default, but you can also specify packages directly
-# (e.g `use nix -p ocaml`).
+# used by default unless NIX_NO_WATCH_DEFAULT is set to "true"
+# or by passing `--no-watch-default` as first parameter
+# Arguments are passed to nix-shell as is, eg. you can specify packages directly
+# using `use nix -p ocaml`.
 #
 use_nix() {
+  local NIX_NO_WATCH_DEFAULT="${NIX_NO_WATCH_DEFAULT:-false}"
+  if [[ "${1:-}" == "--no-watch-default" ]]; then
+    NIX_NO_WATCH_DEFAULT="true"
+    shift
+  fi
   direnv_load nix-shell --show-trace "$@" --run "$(join_args "$direnv" dump)"
-  if [[ $# == 0 ]]; then
+  if [[ "${NO_WATCH_DEFAULT:-false}" == "false" ]]; then
     watch_file default.nix
     watch_file shell.nix
   fi


### PR DESCRIPTION
The current implementation of use_nix disables watching the `default.nix` and `shell.nix` files as soon as any arbitrary arguments are passed.
This makes some sense if you assume that one passes only packages to nix-shell that should be used instead of the shell files.
However, nix-shell accepts a lot of other useful options, like cache control, build concurrency control and others. Turning of watching the default files in these cases is not expected.
This pull request decouples the fact of whether the default nix files should be watched from the nix-shell arguments. Instead, a specific argument is added that can be passed to configure this behavior.