### PR TITLE
stdlib: venv and pyenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /test/allow
 /test/direnv
 /test/config/direnv/allow
+/test/scenarios/inherited/.envrc

--- a/stdlib.go
+++ b/stdlib.go
@@ -425,9 +425,10 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"\n" +
 	"# Usage: layout python <python_exe>\n" +
 	"#\n" +
-	"# Creates and loads a virtualenv environment under\n" +
+	"# Creates and loads a virtual environment under\n" +
 	"# \"$direnv_layout_dir/python-$python_version\".\n" +
 	"# This forces the installation of any egg into the project's sub-folder.\n" +
+	"# For python older then 3.3 this requires virtualenv to be installed.\n" +
 	"#\n" +
 	"# It's possible to specify the python executable if you want to use different\n" +
 	"# versions of python.\n" +
@@ -451,7 +452,11 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"    VIRTUAL_ENV=$(direnv_layout_dir)/python-$python_version\n" +
 	"    export VIRTUAL_ENV\n" +
 	"    if [[ ! -d $VIRTUAL_ENV ]]; then\n" +
-	"      virtualenv \"--python=$python\" \"$@\" \"$VIRTUAL_ENV\"\n" +
+	"      if $python -c \"import venv\"; then\n" +
+	"        $python -m venv \"$@\" \"$VIRTUAL_ENV\"\n" +
+	"      else\n" +
+	"        virtualenv \"--python=$python\" \"$@\" \"$VIRTUAL_ENV\"\n" +
+	"      fi\n" +
 	"    fi\n" +
 	"  fi\n" +
 	"  PATH_add \"$VIRTUAL_ENV/bin\"\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -544,6 +544,29 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"  export VIRTUAL_ENV\n" +
 	"}\n" +
 	"\n" +
+	"# Usage: layout pyenv <python version number>\n" +
+	"#\n" +
+	"# Example:\n" +
+	"#\n" +
+	"#    layout pyenv 3.6.7\n" +
+	"#\n" +
+	"# Uses pyenv and layout_python to create and load a virtual environment under\n" +
+	"# \"$direnv_layout_dir/python-$python_version\".\n" +
+	"#\n" +
+	"layout_pyenv() {\n" +
+	"  local python_version=$1\n" +
+	"  local pyenv_python\n" +
+	"  pyenv_python=$(pyenv root)/versions/${python_version}/bin/python\n" +
+	"  if [[ -x \"$pyenv_python\" ]]; then\n" +
+	"    if layout_python \"$pyenv_python\"; then\n" +
+	"      export PYENV_VERSION=$python_version\n" +
+	"    fi\n" +
+	"  else\n" +
+	"    log_error \"pyenv: version '$python_version' not installed\"\n" +
+	"    return 1\n" +
+	"  fi\n" +
+	"}\n" +
+	"\n" +
 	"# Usage: layout ruby\n" +
 	"#\n" +
 	"# Sets the GEM_HOME environment variable to \"$(direnv_layout_dir)/ruby/RUBY_VERSION\".\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -423,9 +423,10 @@ layout_php() {
 
 # Usage: layout python <python_exe>
 #
-# Creates and loads a virtualenv environment under
+# Creates and loads a virtual environment under
 # "$direnv_layout_dir/python-$python_version".
 # This forces the installation of any egg into the project's sub-folder.
+# For python older then 3.3 this requires virtualenv to be installed.
 #
 # It's possible to specify the python executable if you want to use different
 # versions of python.
@@ -449,7 +450,11 @@ layout_python() {
     VIRTUAL_ENV=$(direnv_layout_dir)/python-$python_version
     export VIRTUAL_ENV
     if [[ ! -d $VIRTUAL_ENV ]]; then
-      virtualenv "--python=$python" "$@" "$VIRTUAL_ENV"
+      if $python -c "import venv"; then
+        $python -m venv "$@" "$VIRTUAL_ENV"
+      else
+        virtualenv "--python=$python" "$@" "$VIRTUAL_ENV"
+      fi
     fi
   fi
   PATH_add "$VIRTUAL_ENV/bin"

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -542,6 +542,29 @@ layout_pipenv() {
   export VIRTUAL_ENV
 }
 
+# Usage: layout pyenv <python version number>
+#
+# Example:
+#
+#    layout pyenv 3.6.7
+#
+# Uses pyenv and layout_python to create and load a virtual environment under
+# "$direnv_layout_dir/python-$python_version".
+#
+layout_pyenv() {
+  local python_version=$1
+  local pyenv_python
+  pyenv_python=$(pyenv root)/versions/${python_version}/bin/python
+  if [[ -x "$pyenv_python" ]]; then
+    if layout_python "$pyenv_python"; then
+      export PYENV_VERSION=$python_version
+    fi
+  else
+    log_error "pyenv: version '$python_version' not installed"
+    return 1
+  fi
+}
+
 # Usage: layout ruby
 #
 # Sets the GEM_HOME environment variable to "$(direnv_layout_dir)/ruby/RUBY_VERSION".


### PR DESCRIPTION
This is a follow-on to #429, rebased on master, with a couple updates:

* Only invoke python once to determine the Python version and whether venv is available (since invoking the python interpreter is relatively slow)
* Explicitly check for the existence of virtualenv (since it's not part of the standard library)
* Use pkgutil instead of import to check for the availability of venv and virtualenv so we don't output a multiline traceback to stderr if an import fails*
* Don't export VIRTUAL_ENV if neither venv nor virtualenv are available (for folks who set PS1 with the value of VIRTUAL_ENV to indicate that a virtual environment has been successfully activated, this would otherwise be quite misleading)

This PR also adds `/test/scenarios/inherited/.envrc` to .gitignore, which is generated by `direnv-test.bash`.

Finally, this PR also adds a commit to support [pyenv](/pyenv/pyenv) (like rbenv--in fact, pyenv was forked from it).

\* For example, in Python < 3.3, `python -c "import venv"` yields:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named venv
```

