### PR TITLE
Handle failing pipenv on missing venv and avoid an extra pipenv execution

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -511,20 +511,18 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"# virtualenv from the Pipfile located in the same directory.\n" +
 	"#\n" +
 	"layout_pipenv() {\n" +
-	"  local venv\n" +
 	"  PIPENV_PIPFILE=\"${PIPENV_PIPFILE:-Pipfile}\"\n" +
 	"  if [[ ! -f \"$PIPENV_PIPFILE\" ]]; then\n" +
 	"    log_error \"No Pipfile found.  Use \\`pipenv\\` to create a \\`$PIPENV_PIPFILE\\` first.\"\n" +
 	"    exit 2\n" +
 	"  fi\n" +
 	"\n" +
-	"  venv=$(pipenv --bare --venv 2>/dev/null)\n" +
+	"  VIRTUAL_ENV=$(pipenv --venv 2>/dev/null ; true)\n" +
 	"\n" +
-	"  if [[ -z $venv || ! -d $venv ]]; then\n" +
+	"  if [[ -z $VIRTUAL_ENV || ! -d $VIRTUAL_ENV ]]; then\n" +
 	"    pipenv install --dev\n" +
+	"    VIRTUAL_ENV=$(pipenv --venv)\n" +
 	"  fi\n" +
-	"\n" +
-	"  VIRTUAL_ENV=$(pipenv --venv)\n" +
 	"\n" +
 	"  PATH_add \"$VIRTUAL_ENV/bin\"\n" +
 	"  export PIPENV_ACTIVE=1\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -509,20 +509,18 @@ layout_anaconda() {
 # virtualenv from the Pipfile located in the same directory.
 #
 layout_pipenv() {
-  local venv
   PIPENV_PIPFILE="${PIPENV_PIPFILE:-Pipfile}"
   if [[ ! -f "$PIPENV_PIPFILE" ]]; then
     log_error "No Pipfile found.  Use \`pipenv\` to create a \`$PIPENV_PIPFILE\` first."
     exit 2
   fi
 
-  venv=$(pipenv --bare --venv 2>/dev/null)
+  VIRTUAL_ENV=$(pipenv --venv 2>/dev/null ; true)
 
-  if [[ -z $venv || ! -d $venv ]]; then
+  if [[ -z $VIRTUAL_ENV || ! -d $VIRTUAL_ENV ]]; then
     pipenv install --dev
+    VIRTUAL_ENV=$(pipenv --venv)
   fi
-
-  VIRTUAL_ENV=$(pipenv --venv)
 
   PATH_add "$VIRTUAL_ENV/bin"
   export PIPENV_ACTIVE=1


### PR DESCRIPTION
Fixes `layout_pipenv`'s check for a venv path. For some reason, the error from `pipenv --bare --venv` when the venv doesn't exist does not exit the script in bash 5.0 (brew), but does in bash 3.2 (macos stock). Perhaps there needs to be some follow up investigation on if `set -e` is being enforced properly for bash 5.0.

This also removes an extra `pipenv --venv` lookup when it's already created, which will be every time except possibly the first, which should speed up loading a bit.

Resolves direnv/direnv#500