### PR TITLE
Use `fish_preexec` event instead of `fish_prompt`

### DIFF
--- a/shell_fish.go
+++ b/shell_fish.go
@@ -10,7 +10,7 @@ type fish struct{}
 var FISH Shell = fish{}
 
 const FISH_HOOK = `
-function __direnv_export_eval --on-event fish_prompt;
+function __direnv_export_eval --on-event fish_preexec;
 	"{{.SelfPath}}" export fish | source;
 end
 `


### PR DESCRIPTION
This is more reliable, as `fish_prompt` could miss changing directories with Alt+Left/Right. It also runs when pressing enter on an empty shell, so as far as I can tell it's a superset of `fish_prompt`.

The preexec event was added to fish in https://github.com/fish-shell/fish-shell/pull/1666, which was after this line was last touched :) By now, even Debian should have a recent-enough fish to support this.