### PR TITLE
shell: improve zsh hook

### DIFF
--- a/shell_zsh.go
+++ b/shell_zsh.go
@@ -11,7 +11,11 @@ _direnv_hook() {
 }
 typeset -ag precmd_functions;
 if [[ -z ${precmd_functions[(r)_direnv_hook]} ]]; then
-  precmd_functions+=_direnv_hook;
+  precmd_functions=( _direnv_hook ${precmd_functions[@]} )
+fi
+typeset -ag chpwd_functions;
+if [[ -z ${chpwd_functions[(r)_direnv_hook]} ]]; then
+  chpwd_functions=( _direnv_hook ${chpwd_functions[@]} )
 fi
 `
 


### PR DESCRIPTION
Prepend but not append `_direnv_hook` to make sure environment variables are changed before any other hooks, in case the vars are used by other hooks. This is what bash does with `PROMPT_COMMAND` in `shell_bash.go`.

Besides, add `_direnv_hook` into `chpwd` hook, which is triggered once working dir is changed by ZLE widget but not command `cd` in ZSH.