### PR TITLE
Watch more than one file at a time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+UNRELEASED
+==========
+
+  * CHANGE: Watch multiple files in a single invocation of `watch_file` / `direnv watch`.
 
 2.20.1 / 2019-03-31
 ==================

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -11,7 +11,7 @@ var CmdWatch = &Cmd{
 }
 
 func watchCommand(env Env, args []string) (err error) {
-	var path, shellName string
+	var shellName string
 
 	args = args[1:]
 	if len(args) < 1 {
@@ -30,15 +30,15 @@ func watchCommand(env Env, args []string) (err error) {
 		return fmt.Errorf("Unknown target shell '%s'", shellName)
 	}
 
-	path = args[0]
-
 	watches := NewFileTimes()
 	watchString, ok := env[DIRENV_WATCHES]
 	if ok {
 		watches.Unmarshal(watchString)
 	}
 
-	watches.Update(path)
+	for idx := range args {
+		watches.Update(args[idx])
+	}
 
 	e := make(ShellExport)
 	e.Add(DIRENV_WATCHES, watches.Marshal())

--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -322,9 +322,9 @@ use node 4.2.2
 .fi
 .RE
 
-.SS \fB\fCwatch\_file <path>\fR
+.SS \fB\fCwatch\_file <path> [<path> ...]\fR
 .PP
-Adds a file to direnv's watch\-list. If the file changes direnv will reload the environment on the next prompt.
+Adds each file to direnv's watch\-list. If the file changes direnv will reload the environment on the next prompt.
 
 .PP
 Example (.envrc):

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -221,9 +221,9 @@ Example (.envrc):
     set -e
     use node 4.2.2
 
-### `watch_file <path>`
+### `watch_file <path> [<path> ...]`
 
-Adds a file to direnv's watch-list. If the file changes direnv will reload the environment on the next prompt.
+Adds each file to direnv's watch-list. If the file changes direnv will reload the environment on the next prompt.
 
 Example (.envrc):
 

--- a/stdlib.go
+++ b/stdlib.go
@@ -224,15 +224,14 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"  popd >/dev/null\n" +
 	"}\n" +
 	"\n" +
-	"# Usage: watch_file <filename>\n" +
+	"# Usage: watch_file <filename> [<filename> ...]\n" +
 	"#\n" +
-	"# Adds <path> to the list of files that direnv will watch for changes - useful when the contents\n" +
-	"# of a file influence how variables are set - especially in direnvrc\n" +
+	"# Adds each <filename> to the list of files that direnv will watch for changes -\n" +
+	"# useful when the contents of a file influence how variables are set -\n" +
+	"# especially in direnvrc\n" +
 	"#\n" +
 	"watch_file() {\n" +
-	"  local file=${1/#\\~/$HOME}\n" +
-	"\n" +
-	"  eval \"$(\"$direnv\" watch \"$file\")\"\n" +
+	"  eval \"$(\"$direnv\" watch \"$@\")\"\n" +
 	"}\n" +
 	"\n" +
 	"# Usage: source_up [<filename>]\n" +
@@ -727,8 +726,7 @@ const STDLIB = "#!/usr/bin/env bash\n" +
 	"use_nix() {\n" +
 	"  direnv_load nix-shell --show-trace \"$@\" --run \"$(join_args \"$direnv\" dump)\"\n" +
 	"  if [[ $# == 0 ]]; then\n" +
-	"    watch_file default.nix\n" +
-	"    watch_file shell.nix\n" +
+	"    watch_file default.nix shell.nix\n" +
 	"  fi\n" +
 	"}\n" +
 	"\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -222,15 +222,14 @@ source_env() {
   popd >/dev/null
 }
 
-# Usage: watch_file <filename>
+# Usage: watch_file <filename> [<filename> ...]
 #
-# Adds <path> to the list of files that direnv will watch for changes - useful when the contents
-# of a file influence how variables are set - especially in direnvrc
+# Adds each <filename> to the list of files that direnv will watch for changes -
+# useful when the contents of a file influence how variables are set -
+# especially in direnvrc
 #
 watch_file() {
-  local file=${1/#\~/$HOME}
-
-  eval "$("$direnv" watch "$file")"
+  eval "$("$direnv" watch "$@")"
 }
 
 # Usage: source_up [<filename>]
@@ -725,8 +724,7 @@ use_node() {
 use_nix() {
   direnv_load nix-shell --show-trace "$@" --run "$(join_args "$direnv" dump)"
   if [[ $# == 0 ]]; then
-    watch_file default.nix
-    watch_file shell.nix
+    watch_file default.nix shell.nix
   fi
 }
 


### PR DESCRIPTION
The rationale is that when watching a large number of files it can take a noticeable amount of time to add all the watches.

This also removes the code that replaces leading tildes with `$HOME` on the filename passed to watch_file. A leading tilde is typically replaced by the shell. By doing it a second time it complicates watching files that do actually begin with a tilde. But I'm happy to put it back in (and make it work for multiple files) if removing it is a blocker.