### PR TITLE
docs: fix invalid link

### DIFF
--- a/docs/ruby.md
+++ b/docs/ruby.md
@@ -36,7 +36,8 @@ a descriptive syntax like `use ruby 1.9.3` to selects the right ruby version
 for the project.
 
 For that regard we are going to use a couple of commands available in the
-[direnv stdlib](/stdlib.html) and expand it a bit in the ~/.direnvrc file.
+[direnv stdlib](/man/direnv-stdlib.1.md) and expand it a bit in the ~/.direnvrc
+file.
 
 Add this to the ~/.direnvrc file (you have to create it if it doesn't exist):
 


### PR DESCRIPTION
change link to stdlib from `/stdlib.html` to `/man/direnv-stdlib.1.md`
Closes #532