### PR TITLE
Add link to asdf-direnv.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ submit new ones.
 * [Environment Modules](http://modules.sourceforge.net/) - one of the oldest (in a good way) environment-loading systems
 * [autoenv](https://github.com/kennethreitz/autoenv) - lightweight; doesn't support unloads
 * [zsh-autoenv](https://github.com/Tarrasch/zsh-autoenv) - a feature-rich mixture of autoenv and [smartcd](https://github.com/cxreg/smartcd): enter/leave events, nesting, stashing (Zsh-only).
-* [asdf](https://github.com/asdf-vm/asdf) - a pure bash solution that has a plugin system
+* [asdf](https://github.com/asdf-vm/asdf) - a pure bash solution that has a plugin system. The [asdf-direnv](https://github.com/asdf-community/asdf-direnv) plugin allows using asdf managed tools with direnv.
 
 ## COPYRIGHT
 


### PR DESCRIPTION
[asdf-direnv](https://github.com/asdf-community/asdf-direnv) is an [asdf](https://asdf-vm.com) plugin for integration between asdf and direnv.