### PR TITLE
Use `fish_postexec` to make sure direnv hook executed 'after' the directory has changed when using `cd`.

### DIFF
--- a/shell_fish.go
+++ b/shell_fish.go
@@ -10,7 +10,7 @@ type fish struct{}
 var FISH Shell = fish{}
 
 const FISH_HOOK = `
-function __direnv_export_eval --on-event fish_preexec;
+function __direnv_export_eval --on-event fish_postexec;
 	"{{.SelfPath}}" export fish | source;
 end
 `


### PR DESCRIPTION
Using `fish_preexec` causes Direnv to 'detect' and source the `.envrc` with 1 prompt of lag when changing directories with `cd`. Because the `fish_preexec` seems to be executed before the new directory is entered. 

https://asciinema.org/a/jl7G5qNPNZ0qAVRoTFHHiOMXH

https://github.com/fish-shell/fish-shell/issues/6465