### PR TITLE
stdlib: direnv_load can now handle stdout outputs

### DIFF
--- a/cmd_dump.go
+++ b/cmd_dump.go
@@ -1,18 +1,36 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
-// `direnv dump`
+// CmdDump is `direnv dump`
 var CmdDump = &Cmd{
 	Name:    "dump",
 	Desc:    "Used to export the inner bash state at the end of execution",
-	Args:    []string{"[SHELL]"},
+	Args:    []string{"[SHELL]", "[FILE]"},
 	Private: true,
 	Action: actionSimple(func(env Env, args []string) (err error) {
 		target := "gzenv"
+		w := os.Stdout
 
 		if len(args) > 1 {
 			target = args[1]
+		}
+
+		var filePath string
+		if len(args) > 2 {
+			filePath = args[2]
+		} else {
+			filePath = os.Getenv("DIRENV_DUMP_FILE_PATH")
+		}
+
+		if filePath != "" {
+			w, err = os.OpenFile(filePath, os.O_WRONLY, 0666)
+			if err != nil {
+				return err
+			}
 		}
 
 		shell := DetectShell(target)
@@ -20,7 +38,7 @@ var CmdDump = &Cmd{
 			return fmt.Errorf("unknown target shell '%s'", target)
 		}
 
-		fmt.Println(shell.Dump(env))
+		_, err = fmt.Fprintln(w, shell.Dump(env))
 
 		return
 	}),

--- a/test/scenarios/dump/.envrc
+++ b/test/scenarios/dump/.envrc
@@ -2,5 +2,5 @@ direnv_load env \
 	LS_COLORS='*.ogg=38;5;45:*.wav=38;5;45' \
 	LESSOPEN='||/usr/bin/lesspipe.sh %s' \
 	THREE_BACKSLASHES='\\\' \
-	bash -c "direnv dump"
+	bash -c "echo to stdout && echo to stderr >&2 && direnv dump"
 


### PR DESCRIPTION
Fixes issues where that error message would appear (#519)  :

    direnv: error unmarshal() base64 decoding: illegal base64 data at input byte 0

The issue was that `direnv_load` was reading from the sub-command
stdout, which could also containt content from other commands than
`direnv dump`. This is now solved by opening a fifo pipe between the
load and the dump function.