### PR TITLE
stdlib: add source_url function

### DIFF
--- a/man/direnv-fetchurl.1
+++ b/man/direnv-fetchurl.1
@@ -14,7 +14,8 @@ content of the retrieved file.
 
 .PP
 This has been introduced to avoid a dependency on \fB\fCcurl\fR or \fB\fCwget\fR, while also
-promoting a more secure way to fetch data from the Internet.
+promoting a more secure way to fetch data from the Internet. Use this instead
+of \fB\fCcurl <url> | sh\fR\&.
 
 .PP
 This command has two modes of operation:
@@ -29,7 +30,8 @@ implication of this design is that URLs must be stable and always return the
 same content.
 
 .PP
-Downloaded files are marked as read\-only and executable.
+Downloaded files are marked as read\-only and executable so it can also be used
+to fetch and execute static binaries.
 
 .SH OPTIONS
 .PP

--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -108,6 +108,29 @@ Loads another \fB\fC\&.envrc\fR if found when searching from the parent director
 .PP
 NOTE: the other \fB\fC\&.envrc\fR is not checked by the security framework.
 
+.SS \fB\fCsource\_url <url> <integrity\-hash>\fR
+.PP
+Loads another script from the given \fB\fCurl\fR\&. Before loading it it will check the
+integrity using the provided \fB\fCintegrity\-hash\fR\&.
+
+.PP
+To find the value of the \fB\fCintegrity\-hash\fR, call \fB\fCdirenv fetchurl <url>\fR and
+extract the hash from the outputted message.
+
+.PP
+See also \fB\fCdirenv\-fetchurl(1)\fR for more details.
+
+.SS \fB\fCfetchurl <url> [<integrity\-hash>]\fR
+.PP
+Fetches the given \fB\fCurl\fR onto disk and outputs it's path location on stdout.
+
+.PP
+If the \fB\fCintegrity\-hash\fR argument is provided, it will also check the integrity
+of the script.
+
+.PP
+See also \fB\fCdirenv\-fetchurl(1)\fR for more details.
+
 .SS \fB\fCdirenv\_apply\_dump <file>\fR
 .PP
 Loads the output of \fB\fCdirenv dump\fR that was stored in a file.

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -81,6 +81,25 @@ Loads another `.envrc` if found when searching from the parent directory up to /
 
 NOTE: the other `.envrc` is not checked by the security framework.
 
+### `source_url <url> <integrity-hash>`
+
+Loads another script from the given `url`. Before loading it it will check the
+integrity using the provided `integrity-hash`.
+
+To find the value of the `integrity-hash`, call `direnv fetchurl <url>` and
+extract the hash from the outputted message.
+
+See also `direnv-fetchurl(1)` for more details.
+
+### `fetchurl <url> [<integrity-hash>]`
+
+Fetches the given `url` onto disk and outputs it's path location on stdout.
+
+If the `integrity-hash` argument is provided, it will also check the integrity
+of the script.
+
+See also `direnv-fetchurl(1)` for more details.
+
 ### `direnv_apply_dump <file>`
 
 Loads the output of `direnv dump` that was stored in a file.

--- a/stdlib.go
+++ b/stdlib.go
@@ -269,6 +269,34 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  fi\n" +
 	"}\n" +
 	"\n" +
+	"# Usage: fetchurl <url> [<integrity-hash>]\n" +
+	"#\n" +
+	"# Fetches a URL and outputs a file with its content. If the <integrity-hash>\n" +
+	"# is given it will also validate the content of the file before returning it.\n" +
+	"fetchurl() {\n" +
+	"  \"$direnv\" fetchurl \"$@\"\n" +
+	"}\n" +
+	"\n" +
+	"# Usage: source_url <url> <integrity-hash>\n" +
+	"#\n" +
+	"# Fetches a URL and evalutes its content.\n" +
+	"source_url() {\n" +
+	"  local url=$1 integrity_hash=${2:-} path\n" +
+	"  if [[ -z $url ]]; then\n" +
+	"    log_error \"source_url: <url> argument missing\"\n" +
+	"    return 1\n" +
+	"  fi\n" +
+	"  if [[ -z $integrity_hash ]]; then\n" +
+	"    log_error \"source_url: <integrity-hash> argument missing. Use \\`direnv fetchurl $url\\` to find out the hash.\"\n" +
+	"    return 1\n" +
+	"  fi\n" +
+	"\n" +
+	"  log_status \"loading $url ($integrity_hash)\"\n" +
+	"  path=$(fetchurl \"$url\" \"$integrity_hash\")\n" +
+	"  # shellcheck disable=SC1090\n" +
+	"  source \"$path\"\n" +
+	"}\n" +
+	"\n" +
 	"# Usage: direnv_load <command-generating-dump-output>\n" +
 	"#   e.g: direnv_load opam-env exec -- \"$direnv\" dump\n" +
 	"#\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -266,6 +266,34 @@ source_up() {
   fi
 }
 
+# Usage: fetchurl <url> [<integrity-hash>]
+#
+# Fetches a URL and outputs a file with its content. If the <integrity-hash>
+# is given it will also validate the content of the file before returning it.
+fetchurl() {
+  "$direnv" fetchurl "$@"
+}
+
+# Usage: source_url <url> <integrity-hash>
+#
+# Fetches a URL and evalutes its content.
+source_url() {
+  local url=$1 integrity_hash=${2:-} path
+  if [[ -z $url ]]; then
+    log_error "source_url: <url> argument missing"
+    return 1
+  fi
+  if [[ -z $integrity_hash ]]; then
+    log_error "source_url: <integrity-hash> argument missing. Use \`direnv fetchurl $url\` to find out the hash."
+    return 1
+  fi
+
+  log_status "loading $url ($integrity_hash)"
+  path=$(fetchurl "$url" "$integrity_hash")
+  # shellcheck disable=SC1090
+  source "$path"
+}
+
 # Usage: direnv_load <command-generating-dump-output>
 #   e.g: direnv_load opam-env exec -- "$direnv" dump
 #


### PR DESCRIPTION
Provide an easy way to extend the stdlib with scripts from the Internet.
While still enforcing some level of security.
    
Eg:
    
    source_url "https://raw.githubusercontent.com/nmattia/sorri/bff9e44734b19d5c65534c9bfd10bdf3be90b623/sorri" "sha256-CMbjOcSXWtTqSW0jKBPWWPBMBiOvJsh2vnFJoQJ6yFM="
    
To find out the hash, get the immutable script URL, then run `direnv fetchurl <url>` to get back the hash.
