### PR TITLE
Simplify direnv_load and make it work even when the command crashes.

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -268,7 +268,10 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  local temp_dir output_file script_file exit_code\n" +
 	"\n" +
 	"  # Prepare a temporary place for dumps and such.\n" +
-	"  temp_dir=$(mktemp -dt direnv.XXXXXX)\n" +
+	"  temp_dir=$(mktemp -dt direnv.XXXXXX) || {\n" +
+	"    log_error \"Could not create temporary directory.\"\n" +
+	"    return 1\n" +
+	"  }\n" +
 	"  output_file=\"$temp_dir/output\"\n" +
 	"  script_file=\"$temp_dir/script\"\n" +
 	"\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -265,7 +265,10 @@ direnv_load() {
   local temp_dir output_file script_file exit_code
 
   # Prepare a temporary place for dumps and such.
-  temp_dir=$(mktemp -dt direnv.XXXXXX)
+  temp_dir=$(mktemp -dt direnv.XXXXXX) || {
+    log_error "Could not create temporary directory."
+    return 1
+  }
   output_file="$temp_dir/output"
   script_file="$temp_dir/script"
 

--- a/test/scenarios/dump/.envrc
+++ b/test/scenarios/dump/.envrc
@@ -4,3 +4,7 @@ direnv_load env \
 	THREE_BACKSLASHES='\\\' \
 	bash -c "echo to stdout && echo to stderr >&2 && direnv dump"
 
+log_status "direnv_load would previously hang if DIRENV_DUMP_FILE_PATH was not opened."
+log_status "Expect the following to emit an error (which we suppress)."
+log_status "As long as it doesn't hang, we're okay."
+direnv_load true || true


### PR DESCRIPTION
Fixes #569.

Previously a call to, for example, `direnv_load true` would cause direnv to hang. This is because the command didn't include a call to `direnv dump`, hence nothing ever wrote to the far end of the named pipe that had been created to receive the output from the given command, `true`.

Another example:

```
direnv_load bash -c 'do_something_that_breaks && direnv dump'
```

In this instance we've rememebered to call `direnv dump`, but it is never called because `do_something_that_breaks` returns non-zero.