### PR TITLE
Add strict_env and unstrict_env

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -474,6 +474,78 @@ Checks that the direnv version is at least old as \fB\fCversion\_at\_least\fR\&.
 be useful when sharing an \fB\fC\&.envrc\fR and to make sure that the users are up to
 date.
 
+.SS \fB\fCstrict\_env [<command> ...]\fR
+.PP
+Turns on shell execution strictness. This will force the .envrc
+evaluation context to exit immediately if:
+.IP \(bu 2
+any command in a pipeline returns a non\-zero exit status that is not
+otherwise handled as part of \fB\fCif\fR, \fB\fCwhile\fR, or \fB\fCuntil\fR tests,
+return value negation (\fB\fC!\fR), or part of a boolean (\fB\fC\&\&\fR or \fB\fC||\fR)
+chain.
+.IP \(bu 2
+any variable that has not explicitly been set or declared (with
+either \fB\fCdeclare\fR or \fB\fClocal\fR) is referenced.
+
+.PP
+If followed by a command\-line, the strictness applies for the duration
+of the command.
+
+.PP
+Example (Whole Script):
+
+.PP
+.RS
+
+.nf
+strict\_env
+has curl
+
+.fi
+.RE
+
+.PP
+Example (Command):
+
+.PP
+.RS
+
+.nf
+strict\_env has curl
+
+.fi
+.RE
+
+.SS \fB\fCunstrict\_env [<command> ...]\fR
+.PP
+Turns off shell execution strictness. If followed by a command\-line, the
+strictness applies for the duration of the command.
+
+.PP
+Example (Whole Script):
+
+.PP
+.RS
+
+.nf
+unstrict\_env
+has curl
+
+.fi
+.RE
+
+.PP
+Example (Command):
+
+.PP
+.RS
+
+.nf
+unstrict\_env has curl
+
+.fi
+.RE
+
 .SH COPYRIGHT
 .PP
 MIT licence \- Copyright (C) 2019 @zimbatm and contributors

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -328,6 +328,45 @@ Checks that the direnv version is at least old as `version_at_least`. This can
 be useful when sharing an `.envrc` and to make sure that the users are up to
 date.
 
+### `strict_env [<command> ...]`
+
+Turns on shell execution strictness. This will force the .envrc
+evaluation context to exit immediately if:
+
+- any command in a pipeline returns a non-zero exit status that is not
+  otherwise handled as part of `if`, `while`, or `until` tests,
+  return value negation (`!`), or part of a boolean (`&&` or `||`)
+  chain.
+- any variable that has not explicitly been set or declared (with
+  either `declare` or `local`) is referenced.
+
+If followed by a command-line, the strictness applies for the duration
+of the command.
+
+Example (Whole Script):
+
+    strict_env
+    has curl
+
+Example (Command):
+
+    strict_env has curl
+
+#### `unstrict_env [<command> ...]`
+
+Turns off shell execution strictness. If followed by a command-line, the
+strictness applies for the duration of the command.
+
+Example (Whole Script):
+
+    unstrict_env
+    has curl
+
+Example (Command):
+
+    unstrict_env has curl
+
+
 COPYRIGHT
 ---------
 

--- a/test/stdlib.bash
+++ b/test/stdlib.bash
@@ -155,4 +155,7 @@ test_name source_env_if_exists
   [[ $FOO = bar ]]
 )
 
+# test strict_env and unstrict_env
+./strict_env_test.bash
+
 echo OK

--- a/test/strict_env_test.bash
+++ b/test/strict_env_test.bash
@@ -1,0 +1,67 @@
+#! /usr/bin/env bash
+
+# Note: this is _explicitly_ not setting `set -euo pipefail`
+# because we are testing functions that configure that.
+
+declare base expected actual
+base="${TMPDIR:-/tmp}/$(basename "$0").$$"
+expected="$base".expected
+actual="$base".actual
+
+declare -i success
+success=0
+
+# always execute relative to here
+cd "$(dirname "$0")" || exit 1
+
+# add the built direnv to the path
+root=$(cd .. && pwd -P)
+export PATH=$root:$PATH
+
+load_stdlib() {
+  # shellcheck disable=SC1090
+  source "$root/stdlib.sh"
+}
+
+test_fail() {
+  echo "FAILED $*: expected is not actual"
+  exit 1
+}
+
+test_strictness() {
+  local step
+  step="$1"
+  echo "$2" > "$expected"
+
+  set -o | grep 'errexit\|nounset\|pipefail' > "$actual"
+  diff -u "$expected" "$actual" || test_fail "$step"
+  (( success += 1 ))
+}
+
+load_stdlib
+
+test_strictness 'after source' $'errexit        	off
+nounset        	off
+pipefail       	off'
+
+strict_env
+test_strictness 'after strict_env' $'errexit        	on
+nounset        	on
+pipefail       	on'
+
+unstrict_env echo HELLO > /dev/null
+test_strictness "after unstrict_env with command" $'errexit        	on
+nounset        	on
+pipefail       	on'
+
+strict_env echo HELLO > /dev/null
+test_strictness "after strict_env with command" $'errexit        	on
+nounset        	on
+pipefail       	on'
+
+unstrict_env
+test_strictness 'after unstrict_env' $'errexit        	off
+nounset        	off
+pipefail       	off'
+
+echo "OK ($success tests)"


### PR DESCRIPTION
Allows the gradual introduction of `set -euo pipefail` into envrc processing,
as discussed in #566, as well as an escape hatch for commands that must be run
in the envrc context that do not meet `set -euo pipefail` requirements.