### PR TITLE
config: add strict_env option

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	RCDir           string
 	TomlPath        string
 	DisableStdin    bool
+	StrictEnv       bool
 	WarnTimeout     time.Duration
 	WhitelistPrefix []string
 	WhitelistExact  map[string]bool
@@ -41,6 +42,7 @@ func (d *tomlDuration) UnmarshalText(text []byte) error {
 type tomlConfig struct {
 	BashPath     string       `toml:"bash_path"`
 	DisableStdin bool         `toml:"disable_stdin"`
+	StrictEnv    bool         `toml:"strict_env"`
 	WarnTimeout  tomlDuration `toml:"warn_timeout"`
 	Whitelist    whitelist    `toml:"whitelist"`
 }
@@ -113,8 +115,9 @@ func LoadConfig(env Env) (config *Config, err error) {
 			config.WhitelistExact[path] = true
 		}
 
-		config.DisableStdin = tomlConf.DisableStdin
 		config.BashPath = tomlConf.BashPath
+		config.DisableStdin = tomlConf.DisableStdin
+		config.StrictEnv = tomlConf.StrictEnv
 		config.WarnTimeout = tomlConf.WarnTimeout.Duration
 	}
 

--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -34,7 +34,21 @@ key = "value"
 .PP
 The following sections are supported:
 
-.SH \fB\fCwarn\_timeout\fR
+.SH [global]
+.SS \fB\fCbash\_path\fR
+.PP
+This allows one to hard\-code the position of bash. It maybe be useful to set this to avoid having direnv to fail when PATH is being mutated.
+
+.SS \fB\fCdisable\_stdin\fR
+.PP
+If set to \fB\fCtrue\fR, stdin is disabled (redirected to /dev/null) during the \fB\fC\&.envrc\fR evaluation.
+
+.SS \fB\fCstrict\_env\fR
+.PP
+If set to true, the \fB\fC\&.envrc\fR will be loaded with \fB\fCset \-euo pipefail\fR\&. This
+option will be the default in the future.
+
+.SS \fB\fCwarn\_timeout\fR
 .PP
 Specify how long to wait before warning the user that the command is taking
 too long to execute. Defaults to "5s".
@@ -44,7 +58,7 @@ A duration string is a possibly signed sequence of decimal numbers, each with
 optional fraction and a unit suffix, such as "300ms", "\-1.5h" or "2h45m".
 Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
-.SH \fB\fCwhitelist\fR
+.SH [whitelist]
 .PP
 Specifying whitelist directives marks specific directory hierarchies or specific directories as "trusted" \-\- direnv will evaluate any matching .envrc files regardless of whether they have been specifically allowed. \fBThis feature should be used with great care\fP, as anyone with the ability to write files to that directory (including collaborators on VCS repositories) will be able to execute arbitrary code on your computer.
 
@@ -114,19 +128,6 @@ In this example, the following .envrc files will not be implicitly allowed (alth
 \fB\fC/home/user/code/project\-b/subproject\-c/.envrc\fR
 .IP \(bu 2
 \fB\fC/home/user/code/.envrc\fR
-
-.SH \fB\fCbash\_path\fR
-.PP
-This allows one to hard\-code the position of bash. It maybe be useful to set this to avoid having direnv to fail when PATH is being mutated.
-
-.SH \fB\fCdisable\_stdin\fR
-.PP
-If set to true, stdin is disabled (redirected to /dev/null) during the \fB\fC\&.envrc\fR evaluation.
-
-.SH \fB\fCstrict\_env\fR
-.PP
-If set to true, the \fB\fC\&.envrc\fR will be loaded with \fB\fCset \-euo pipefail\fR\&. This
-option will be the default in the future.
 
 .SH COPYRIGHT
 .PP

--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -123,6 +123,11 @@ This allows one to hard\-code the position of bash. It maybe be useful to set th
 .PP
 If set to true, stdin is disabled (redirected to /dev/null) during the \fB\fC\&.envrc\fR evaluation.
 
+.SH \fB\fCstrict\_env\fR
+.PP
+If set to true, the \fB\fC\&.envrc\fR will be loaded with \fB\fCset \-euo pipefail\fR\&. This
+option will be the default in the future.
+
 .SH COPYRIGHT
 .PP
 MIT licence \- Copyright (C) 2019 @zimbatm and contributors

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -30,7 +30,22 @@ key = "value"
 
 The following sections are supported:
 
-## `warn_timeout`
+## [global]
+
+### `bash_path`
+
+This allows one to hard-code the position of bash. It maybe be useful to set this to avoid having direnv to fail when PATH is being mutated.
+
+### `disable_stdin`
+
+If set to `true`, stdin is disabled (redirected to /dev/null) during the `.envrc` evaluation.
+
+### `strict_env`
+
+If set to true, the `.envrc` will be loaded with `set -euo pipefail`. This
+option will be the default in the future.
+
+### `warn_timeout`
 
 Specify how long to wait before warning the user that the command is taking
 too long to execute. Defaults to "5s".
@@ -39,7 +54,7 @@ A duration string is a possibly signed sequence of decimal numbers, each with
 optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
 Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". 
 
-## `whitelist`
+## [whitelist]
 
 Specifying whitelist directives marks specific directory hierarchies or specific directories as "trusted" -- direnv will evaluate any matching .envrc files regardless of whether they have been specifically allowed. **This feature should be used with great care**, as anyone with the ability to write files to that directory (including collaborators on VCS repositories) will be able to execute arbitrary code on your computer.
 
@@ -87,19 +102,6 @@ In this example, the following .envrc files will not be implicitly allowed (alth
 
 * `/home/user/code/project-b/subproject-c/.envrc`
 * `/home/user/code/.envrc`
-
-## `bash_path`
-
-This allows one to hard-code the position of bash. It maybe be useful to set this to avoid having direnv to fail when PATH is being mutated.
-
-## `disable_stdin`
-
-If set to true, stdin is disabled (redirected to /dev/null) during the `.envrc` evaluation.
-
-## `strict_env`
-
-If set to true, the `.envrc` will be loaded with `set -euo pipefail`. This
-option will be the default in the future.
 
 COPYRIGHT
 ---------

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -96,6 +96,11 @@ This allows one to hard-code the position of bash. It maybe be useful to set thi
 
 If set to true, stdin is disabled (redirected to /dev/null) during the `.envrc` evaluation.
 
+## `strict_env`
+
+If set to true, the `.envrc` will be loaded with `set -euo pipefail`. This
+option will be the default in the future.
+
 COPYRIGHT
 ---------
 

--- a/rc.go
+++ b/rc.go
@@ -146,8 +146,14 @@ func (rc *RC) Load(ctx context.Context, config *Config, env Env) (newEnv Env, er
 		return
 	}
 
+	prelude := ""
+	if config.StrictEnv {
+		prelude = "set -euo pipefail && "
+	}
+
 	arg := fmt.Sprintf(
-		`eval "$("%s" stdlib)" && __main__ source_env "%s"`,
+		`%seval "$("%s" stdlib)" && __main__ source_env "%s"`,
+		prelude,
 		direnv,
 		rc.Path(),
 	)


### PR DESCRIPTION
When set to true, the `.envrc` will be loaded with the `set -euo
pipefail` flags.