### PR TITLE
stdlib: fix direnv_load

### DIFF
--- a/test/scenarios/dump/.envrc
+++ b/test/scenarios/dump/.envrc
@@ -4,3 +4,7 @@ direnv_load env \
 	THREE_BACKSLASHES='\\\' \
 	bash -c "echo to stdout && echo to stderr >&2 && direnv dump"
 
+if direnv_load true ; then
+  log_status "expected direnv_load to fail"
+  exit 1
+fi


### PR DESCRIPTION
Handle the case where `direnv dump` never gets called in the child
process.