### PR TITLE
stdlib: fix direnv_config_dir usage

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -19,7 +19,7 @@ direnv="$(command -v direnv)"
 DIRENV_LOG_FORMAT="${DIRENV_LOG_FORMAT-direnv: %s}"
 
 # Where direnv configuration should be stored
-direnv_config_dir=${XDG_CONFIG_DIR:-$HOME/.config}/direnv
+direnv_config_dir=${XDG_CONFIG_HOME:-$HOME/.config}/direnv
 
 # This variable can be used by programs to detect when they are running inside
 # of a .envrc evaluation context. It is ignored by the direnv diffing


### PR DESCRIPTION
The stdlib of direnv uses the environment variable XDG_CONFIG_DIR
instead of XDG_CONFIG_HOME to determine the location of the user defined
configuration directory.

Fixes #595