### PR TITLE
Source hash

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -101,6 +101,13 @@ Loads another \fB\fC\&.envrc\fR either by specifying its path or filename.
 .PP
 NOTE: the other \fB\fC\&.envrc\fR is not checked by the security framework.
 
+.SS \fB\fCsource\_hash <file\_or\_dir\_path> <shasum>\fR
+.PP
+Loads another \fB\fC\&.envrc\fR either by specifying its path or filename.
+
+.PP
+The other ".envrc" is validated using shasum check.
+
 .SS \fB\fCsource\_up [<filename>]\fR
 .PP
 Loads another \fB\fC\&.envrc\fR if found when searching from the parent directory up to /.

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -75,6 +75,13 @@ Loads another `.envrc` either by specifying its path or filename.
 
 NOTE: the other `.envrc` is not checked by the security framework.
 
+
+### `source_hash <file_or_dir_path> <shasum>`
+
+Loads another `.envrc` either by specifying its path or filename.
+
+The other ".envrc" is validated using shasum check.
+
 ### `source_up [<filename>]`
 
 Loads another `.envrc` if found when searching from the parent directory up to /.

--- a/script/direnv_update_hash
+++ b/script/direnv_update_hash
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+update_hash() {
+  while IFD=' ' read -r _ _path hash
+  do
+    if [[ -d "$_path" ]]; then
+      rcpath="$_path/.envrc"
+    else
+      rcpath="$_path"
+    fi
+    rchash=$(shasum -t "$rcpath" | cut -d \  -f 1)
+
+    if [[ "$hash" != "$rchash" ]]; then
+      echo "referenced $rcpath has change, rehash ?"
+      echo "------------------"
+      cat "$rcpath"
+      echo "------------------"
+
+      sed -i '/source_hash/ s,'"$_path"'.*,'"$_path"' '"$rchash"',' .envrc
+    fi
+
+  done <<< "$(grep -E '^source_hash' .envrc)"
+}
+
+update_hash

--- a/stdlib.go
+++ b/stdlib.go
@@ -230,6 +230,31 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  popd >/dev/null || return 1\n" +
 	"}\n" +
 	"\n" +
+	"# Usage: source_hash <file_or_dir_path> <shasum>\n" +
+	"#\n" +
+	"# Loads another \".envrc\" either by specifying its path or filename.\n" +
+	"# The other \".envrc\" is validated using shasum check.\n" +
+	"#\n" +
+	"source_hash() {\n" +
+	"  local rcpath=${1/#\\~/$HOME}\n" +
+	"  local hash=${2}\n" +
+	"  local rcfile\n" +
+	"  if [[ -d $rcpath ]]; then\n" +
+	"    rcpath=$rcpath/.envrc\n" +
+	"  fi\n" +
+	"  if [[ ! -e $rcpath ]]; then\n" +
+	"    log_status \"referenced $rcpath does not exist\"\n" +
+	"    return 1\n" +
+	"  fi\n" +
+	"  rchash=$(shasum -t \"$rcpath\" | cut -d \\  -f 1)\n" +
+	"  if [[ \"$hash\" != \"$rchash\" ]]; then\n" +
+	"    log_error \"referenced $rcpath has change, please rehash\"\n" +
+	"    return 1\n" +
+	"  fi\n" +
+	"\n" +
+	"  source_env \"$rcpath\"\n" +
+	"}\n" +
+	"\n" +
 	"# Usage: watch_file <filename> [<filename> ...]\n" +
 	"#\n" +
 	"# Adds each <filename> to the list of files that direnv will watch for changes -\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -227,6 +227,31 @@ source_env() {
   popd >/dev/null || return 1
 }
 
+# Usage: source_hash <file_or_dir_path> <shasum>
+#
+# Loads another ".envrc" either by specifying its path or filename.
+# The other ".envrc" is validated using shasum check.
+#
+source_hash() {
+  local rcpath=${1/#\~/$HOME}
+  local hash=${2}
+  local rcfile
+  if [[ -d $rcpath ]]; then
+    rcpath=$rcpath/.envrc
+  fi
+  if [[ ! -e $rcpath ]]; then
+    log_status "referenced $rcpath does not exist"
+    return 1
+  fi
+  rchash=$(shasum -t "$rcpath" | cut -d \  -f 1)
+  if [[ "$hash" != "$rchash" ]]; then
+    log_error "referenced $rcpath has change, please rehash"
+    return 1
+  fi
+
+  source_env "$rcpath"
+}
+
 # Usage: watch_file <filename> [<filename> ...]
 #
 # Adds each <filename> to the list of files that direnv will watch for changes -

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -187,6 +187,13 @@ test_start "utf-8"
   test_eq "${UTFSTUFF}" "♀♂"
 test_stop
 
+test_start "hash"
+  direnv_eval
+  test_eq "$HELLO" "world"
+  test_eq "$TEST" "1234"
+  test -z "$UNSET"
+test_stop
+
 # Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file
 # BUG: foo/bar is resolved in the .envrc execution context and so can't find
 #      the .envrc file.

--- a/test/scenarios/hash/.envrc
+++ b/test/scenarios/hash/.envrc
@@ -1,0 +1,3 @@
+source_hash envrc.test 228f40df92e538a261071baefe4f48926060f130
+source_hash envrc.ignored
+source_hash ../base 8989705c25c4a9f3f0c7617a762279bf016a269f

--- a/test/scenarios/hash/envrc.ignored
+++ b/test/scenarios/hash/envrc.ignored
@@ -1,0 +1,1 @@
+export UNSET=1234

--- a/test/scenarios/hash/envrc.test
+++ b/test/scenarios/hash/envrc.test
@@ -1,0 +1,1 @@
+export TEST=1234


### PR DESCRIPTION
I implement an alternative solution to resolve #448 . I create a `source_hash` command (a wrapper of `source_env`) that run the external file only if it match the hash given.

Before going further, I want to ask you if this is a good idea?

I think we can add the same mechanism on `use_nix` to optionally validate `shell.nix` file.


Sample usage:

``` bash
$ cat .envrc 
source_hash envrc.test 228f40df92e538a261071baefe4f48926060f130
source_hash notfound.sh
source_hash ../base 8989705c25c4a9f3f0c7617a762279bf016a269f

$ cat subdir/.envrc 
source_env .. 8773e41fb8788695e71cc6a373fbe312517ff18f

$ cd subdir 
direnv: loading ~/git/direnv/test/scenarios/hash/subdir/.envrc
direnv: loading ../.envrc
direnv: loading envrc.test
direnv: referenced notfound.sh does not exist
direnv: loading ../base/.envrc
direnv: export +HELLO +TEST

$ echo "#Add Comment" >> ../envrc.test 
direnv: loading ~/git/direnv/test/scenarios/hash/subdir/.envrc                                                                                           
direnv: loading ../.envrc
direnv: referenced envrc.test has change, please rehash
direnv: referenced notfound.sh does not exist
direnv: loading ../base/.envrc
direnv: export +HELLO

$ sed -i '/source_hash/ s,envrc.test.*,envrc.test '"$(shasum -t "../envrc.test" | cut -d \  -f 1)"',' ../.envrc
direnv: loading ~/git/direnv/test/scenarios/hash/subdir/.envrc                                                                                           
direnv: referenced ../.envrc has change, please rehash

$ sed -i '/source_hash/ s,\.\..*,\.\. '"$(shasum -t "../.envrc" | cut -d \  -f 1)"',' .envrc
direnv: error /home/jlesage/git/direnv/test/scenarios/hash/subdir/.envrc is blocked. Run `direnv allow` to approve its content       
                    
$ direnv allow
direnv: loading ~/git/direnv/test/scenarios/hash/subdir/.envrc                                                                                           
direnv: loading ../.envrc
direnv: loading envrc.test
direnv: referenced notfound.sh does not exist
direnv: loading ../base/.envrc
direnv: export +HELLO +TEST
```

I made a bash script to automatically update hashes (instead of using manual sed). It is not fully functional but before correct all leading bugs I want to integrate this functionality in direnv. My first idea is to create new command on direnv

* `direnv hash --update` : update all `source_hash` reference, like my script `direnv_update_hash` do.
* `direnv hash <file>` : add or update a `source_hash` reference

I also think to add `--hash` parameter on `direnv allow` to automatically hash and allow. Or on `direnv edit` to manually show/edit `source_hash` reference.

What do you think about this solution ?
