### PR TITLE
stdlib: add PATH_rm <pattern> [<pattern> ...]

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -156,6 +156,31 @@ Prepends the expanded \fIpath\fP to the MANPATH environment variable. It takes c
 .PP
 Works like \fB\fCPATH\_add\fR except that it's for an arbitrary \fIvarname\fP\&.
 
+.SS \fB\fCPATH\_rm <pattern> [<pattern> ...]\fR
+.PP
+Removes directories that match any of the given shell patterns from the PATH environment variable. Order of the remaining directories is preserved in the resulting PATH.
+
+.PP
+Bash pattern syntax:
+  
+\[la]https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html\[ra]
+
+.PP
+Example:
+
+.PP
+.RS
+
+.nf
+echo $PATH
+# output: /dontremove/me:/remove/me:/usr/local/bin/:...
+PATH\_rm '/remove/*'
+echo $PATH
+# output: /dontremove/me:/usr/local/bin/:...
+
+.fi
+.RE
+
 .SS \fB\fCload\_prefix <prefix\_path>\fR
 .PP
 Expands some common path variables for the given \fIprefix\_path\fP prefix. This is useful if you installed something in the \fIprefix\_path\fP using \fB\fC\&./configure \-\&\-\&prefix=$prefix\_\&path \&\&\&\& make install\fR and want to use it in the project.

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -113,6 +113,22 @@ Prepends the expanded *path* to the MANPATH environment variable. It takes care 
 
 Works like `PATH_add` except that it's for an arbitrary *varname*.
 
+### `PATH_rm <pattern> [<pattern> ...]`
+
+Removes directories that match any of the given shell patterns from the PATH environment variable. Order of the remaining directories is preserved in the resulting PATH.
+
+Bash pattern syntax:
+  https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html
+
+Example:
+
+    echo $PATH
+    # output: /dontremove/me:/remove/me:/usr/local/bin/:...
+    PATH_rm '/remove/*'
+    echo $PATH
+    # output: /dontremove/me:/usr/local/bin/:...
+
+
 ### `load_prefix <prefix_path>`
 
 Expands some common path variables for the given *prefix_path* prefix. This is useful if you installed something in the *prefix_path* using `./configure --prefix=$prefix_path && make install` and want to use it in the project.

--- a/stdlib.go
+++ b/stdlib.go
@@ -397,7 +397,7 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"#\n" +
 	"# Works like PATH_rm except that it's for an arbitrary <varname>.\n" +
 	"path_rm() {\n" +
-	"  local path i match var_name=\"$1\"\n" +
+	"  local path i discard var_name=\"$1\"\n" +
 	"  # split existing paths into an array\n" +
 	"  declare -a path_array\n" +
 	"  IFS=: read -ra path_array <<<\"${!1}\"\n" +
@@ -406,16 +406,16 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  patterns=(\"$@\")\n" +
 	"  results=()\n" +
 	"\n" +
-	"  # iterate over path entries and test for pattern match\n" +
+	"  # iterate over path entries, discard entries that match any of the patterns\n" +
 	"  for path in \"${path_array[@]}\"; do\n" +
-	"    match=false\n" +
+	"    discard=false\n" +
 	"    for pattern in \"${patterns[@]}\"; do\n" +
 	"      if [[ \"$path\" == +($pattern) ]]; then\n" +
-	"        match=true\n" +
+	"        discard=true\n" +
 	"        break\n" +
 	"      fi\n" +
 	"    done\n" +
-	"    if ! $match; then\n" +
+	"    if ! $discard; then\n" +
 	"      results+=(\"$path\")\n" +
 	"    fi\n" +
 	"  done\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -416,7 +416,7 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"      fi\n" +
 	"    done\n" +
 	"    if ! $match; then\n" +
-	"      results+=($path)\n" +
+	"      results+=(\"$path\")\n" +
 	"    fi\n" +
 	"  done\n" +
 	"\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -13,6 +13,7 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"# SC2059: Don't use variables in the printf format string. Use printf \"..%s..\" \"$foo\".\n" +
 	"shopt -s gnu_errfmt\n" +
 	"shopt -s nullglob\n" +
+	"shopt -s extglob\n" +
 	"\n" +
 	"\n" +
 	"# NOTE: don't touch the RHS, it gets replaced at runtime\n" +
@@ -370,6 +371,63 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  local dir\n" +
 	"  dir=$(expand_path \"$1\")\n" +
 	"  export \"MANPATH=$dir:$old_paths\"\n" +
+	"}\n" +
+	"\n" +
+	"# Usage: PATH_rm <pattern> [<pattern> ...]\n" +
+	"# Removes directories that match any of the given shell patterns from\n" +
+	"# the PATH environment variable. Order of the remaining directories is\n" +
+	"# preserved in the resulting PATH.\n" +
+	"#\n" +
+	"# Bash pattern syntax:\n" +
+	"#   https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html\n" +
+	"#\n" +
+	"# Example:\n" +
+	"#\n" +
+	"#   echo $PATH\n" +
+	"#   # output: /dontremove/me:/remove/me:/usr/local/bin/:...\n" +
+	"#   PATH_rm '/remove/*'\n" +
+	"#   echo $PATH\n" +
+	"#   # output: /dontremove/me:/usr/local/bin/:...\n" +
+	"#\n" +
+	"PATH_rm() {\n" +
+	"  path_rm PATH \"$@\"\n" +
+	"}\n" +
+	"\n" +
+	"# Usage: path_rm <varname> <pattern> [<pattern> ...]\n" +
+	"#\n" +
+	"# Works like PATH_rm except that it's for an arbitrary <varname>.\n" +
+	"path_rm() {\n" +
+	"  local path i match var_name=\"$1\"\n" +
+	"  # split existing paths into an array\n" +
+	"  declare -a path_array\n" +
+	"  IFS=: read -ra path_array <<<\"${!1}\"\n" +
+	"  shift\n" +
+	"\n" +
+	"  patterns=(\"$@\")\n" +
+	"  results=()\n" +
+	"\n" +
+	"  # iterate over path entries and test for pattern match\n" +
+	"  for path in \"${path_array[@]}\"; do\n" +
+	"    match=false\n" +
+	"    for pattern in \"${patterns[@]}\"; do\n" +
+	"      if [[ \"$path\" == +($pattern) ]]; then\n" +
+	"        match=true\n" +
+	"        break\n" +
+	"      fi\n" +
+	"    done\n" +
+	"    if ! $match; then\n" +
+	"      results+=($path)\n" +
+	"    fi\n" +
+	"  done\n" +
+	"\n" +
+	"  # join the result paths\n" +
+	"  result=$(\n" +
+	"    IFS=:\n" +
+	"    echo \"${results[*]}\"\n" +
+	"  )\n" +
+	"\n" +
+	"  # and finally export back the result to the original variable\n" +
+	"  export \"$var_name=$result\"\n" +
 	"}\n" +
 	"\n" +
 	"# Usage: load_prefix <prefix_path>\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -413,7 +413,7 @@ path_rm() {
       fi
     done
     if ! $match; then
-      results+=($path)
+      results+=("$path")
     fi
   done
 

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -394,7 +394,7 @@ PATH_rm() {
 #
 # Works like PATH_rm except that it's for an arbitrary <varname>.
 path_rm() {
-  local path i match var_name="$1"
+  local path i discard var_name="$1"
   # split existing paths into an array
   declare -a path_array
   IFS=: read -ra path_array <<<"${!1}"
@@ -403,16 +403,16 @@ path_rm() {
   patterns=("$@")
   results=()
 
-  # iterate over path entries and test for pattern match
+  # iterate over path entries, discard entries that match any of the patterns
   for path in "${path_array[@]}"; do
-    match=false
+    discard=false
     for pattern in "${patterns[@]}"; do
       if [[ "$path" == +($pattern) ]]; then
-        match=true
+        discard=true
         break
       fi
     done
-    if ! $match; then
+    if ! $discard; then
       results+=("$path")
     fi
   done

--- a/test/stdlib.bash
+++ b/test/stdlib.bash
@@ -50,4 +50,24 @@ test_name direnv_apply_dump
   assert_eq "$FOO" bar
 )
 
+test_name PATH_rm
+(
+  load_stdlib
+
+  export PATH=/usr/local/bin:/home/foo/bin:/usr/bin:/home/foo/.local/bin
+  PATH_rm '/home/foo/*'
+
+  assert_eq "$PATH" /usr/local/bin:/usr/bin
+)
+
+test_name path_rm
+(
+  load_stdlib
+
+  somevar=/usr/local/bin:/usr/bin:/home/foo/.local/bin
+  path_rm somevar '/home/foo/*'
+
+  assert_eq "$somevar" /usr/local/bin:/usr/bin
+)
+
 echo OK


### PR DESCRIPTION
When working on a machine with a managed development environment, it's common for the managed `PATH` to have many entries. `PATH_rm` allows me to selectively remove entries that conflict with specific projects.

Example:

    echo $PATH
    # output: /opt/my_employer/thing1/bin:/opt/my_employer/thing2/bin:/usr/local/bin/:...
    PATH_rm '/opt/my_employer/*'
    echo $PATH
    # output: /usr/local/bin/:...
