### PR TITLE
direnv-stdlib.1: add layout php

### DIFF
--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -161,6 +161,10 @@ Sets the GOPATH environment variable to the current directory.
 
 Adds "$PWD/node_modules/.bin" to the PATH environment variable.
 
+### `layout php`
+
+Adds "$PWD/vendor/bin" to the PATH environment variable.
+
 ### `layout perl`
 
 Setup environment variables required by perl's local::lib See http://search.cpan.org/dist/local-lib/lib/local/lib.pm for more details.


### PR DESCRIPTION
I noticed that I have `layout php` in one project and `layout_php` in another and wondered what is the canonical one that should be used.

looked up in documentation and did notice `layout php` missing:
- https://direnv.net/man/direnv-stdlib.1.html#codelayout-lttypegtcode