### PR TITLE
stdlib: `layout go` adds layout dir to GOPATH

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -474,10 +474,11 @@ layout() {
 
 # Usage: layout go
 #
-# Sets the GOPATH environment variable to the current directory.
+# Adds "$(direnv_layout_dir)/go" to the GOPATH environment variable.
+# And also adds "$PWD/bin" to the PATH environment variable.
 #
 layout_go() {
-  path_add GOPATH "$PWD"
+  path_add GOPATH "$(direnv_layout_dir)/go"
   PATH_add bin
 }
 


### PR DESCRIPTION
Update `layout go` so that the layout dir is added to GOPATH instead of PWD.

Since go does not want to see `go.mod` in GOPATH, PWD is not available sometimes.