### PR TITLE
Remove ">" typo in Fish hook instructions

### DIFF
--- a/docs/hook.md
+++ b/docs/hook.md
@@ -28,7 +28,7 @@ eval "$(direnv hook zsh)"
 
 Add the following line at the end of the `~/.config/fish/config.fish` file:
 
-```fish
+```sh
 eval (direnv hook fish)
 ```
 


### PR DESCRIPTION
For some reason, the Fish example was rendering with a ">" at the beginning, even though ">" wasn't present in the code itself. This is invalid, no ">" is needed. I changed the backtick language from `fish` to `sh` like the others, and it seemed to stop rendering a ">".