### PR TITLE
Update direnv-test.elv

### DIFF
--- a/test/direnv-test.elv
+++ b/test/direnv-test.elv
@@ -1,6 +1,6 @@
 #!/usr/bin/env elvish
 
-E:TEST_DIR = (path-dir (src)[path])
+E:TEST_DIR = (path-dir (src)[name])
 set-env XDG_CONFIG_HOME $E:TEST_DIR/config
 set-env XDG_DATA_HOME $E:TEST_DIR/data
 E:PATH = (path-dir $E:TEST_DIR):$E:PATH


### PR DESCRIPTION
The "path" field of (src) has been removed. Use "name" to get the path of file sources.