### PR TITLE
Make `direnv hook` output work on Windows

### DIFF
--- a/cmd_hook.go
+++ b/cmd_hook.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/template"
 )
 
@@ -32,6 +33,8 @@ func cmdHookAction(env Env, args []string) (err error) {
 		return err
 	}
 
+	// Convert Windows path if needed
+	selfPath = strings.Replace(selfPath, "\\", "/", -1)
 	ctx := HookContext{selfPath}
 
 	shell := DetectShell(target)


### PR DESCRIPTION
Without this fix, you have to write your own `_direnv_hook` to run on Cygwin or msys/git bash, because the backslashes are currently interpreted as escapes within the string, rather than actual characters.

(Technically, all the Hook functions should be escaping `.SelfPath` in their templates, but that's a *much* bigger change since most of the shell implementations don't have an escape method, and doing the escaping internal to the Hook method means changing a lot of files.)