### PR TITLE
Fix #594 - write error to fd 3 on Windows

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -870,7 +870,7 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"\n" +
 	"  __dump_at_exit() {\n" +
 	"    local ret=$?\n" +
-	"    \"$direnv\" dump json 3\n" +
+	"    \"$direnv\" dump json \"\" >&3\n" +
 	"    trap - EXIT\n" +
 	"    exit \"$ret\"\n" +
 	"  }\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -868,7 +868,7 @@ __main__() {
 
   __dump_at_exit() {
     local ret=$?
-    "$direnv" dump json 3
+    "$direnv" dump json "" >&3
     trap - EXIT
     exit "$ret"
   }


### PR DESCRIPTION
I didn't remove the fd# support from cmd_dump, but it's not needed any more.

(I'd like to also get rid of `DIRENV_DUMPFILE_PATH`, as it seems like a bug magnet.  But with fd's not working on Windows, I'm not sure what I'd replace it *with*.)