### PR TITLE
Streamline core algorithm of export and exec

### DIFF
--- a/cmd_exec.go
+++ b/cmd_exec.go
@@ -53,8 +53,7 @@ func cmdExecAction(env Env, args []string, config *Config) (err error) {
 
 	// Load the rc
 	if toLoad := findUp(rcPath, ".envrc"); toLoad != "" {
-		newEnv, err = config.EnvFromRC(toLoad, previousEnv)
-		if err != nil {
+		if newEnv, err = config.EnvFromRC(toLoad, previousEnv); err != nil {
 			return
 		}
 	} else {

--- a/cmd_exec.go
+++ b/cmd_exec.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,10 +17,10 @@ var CmdExec = &Cmd{
 
 func cmdExecAction(env Env, args []string, config *Config) (err error) {
 	var (
-		backupDiff *EnvDiff
-		newEnv     Env
-		rcPath     string
-		command    string
+		newEnv      Env
+		previousEnv Env
+		rcPath      string
+		command     string
 	)
 
 	if len(args) < 2 {
@@ -46,20 +45,16 @@ func cmdExecAction(env Env, args []string, config *Config) (err error) {
 		args = args[1:]
 	}
 
-	rc, err := FindRC(rcPath, config)
-	if err != nil {
+	// Restore pristine environment if needed
+	if previousEnv, err = config.Revert(env); err != nil {
 		return
 	}
-
-	// Restore pristine environment if needed
-	if backupDiff, err = config.EnvDiff(); err == nil && backupDiff != nil {
-		env = backupDiff.Reverse().Patch(env)
-	}
-	env.CleanContext()
+	previousEnv.CleanContext()
 
 	// Load the rc
-	if rc != nil {
-		if newEnv, err = rc.Load(context.Background(), config, env); err != nil {
+	if toLoad := findUp(rcPath, ".envrc"); toLoad != "" {
+		newEnv, err = config.EnvFromRC(toLoad, previousEnv)
+		if err != nil {
 			return
 		}
 	} else {

--- a/cmd_export.go
+++ b/cmd_export.go
@@ -77,9 +77,14 @@ func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 		newEnv, err = config.EnvFromRC(toLoad, previousEnv)
 		if err != nil {
 			logDebug("err: %v", err)
-			return
-		} else if newEnv == nil {
-			logDebug("newEnv nil, exiting")
+			// If loading fails, fall through and deliver a diff anyway,
+			// but still exit with an error.  This prevents retrying on
+			// every prompt.
+		}
+		if newEnv == nil {
+			// unless of course, the error was in hashing and timestamp loading,
+			// in which case we have to abort because we don't know what timestamp
+			// to put in the diff!
 			return
 		}
 	}

--- a/cmd_export.go
+++ b/cmd_export.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
-	"os"
-	"os/signal"
 	"sort"
 	"strings"
 )
@@ -16,35 +13,13 @@ var CmdExport = &Cmd{
 	Desc:    "loads an .envrc and prints the diff in terms of exports",
 	Args:    []string{"SHELL"},
 	Private: true,
-	Action:  cmdWithWarnTimeout(actionWithConfig(actionWithCancel(exportCommand))),
+	Action:  cmdWithWarnTimeout(actionWithConfig(exportCommand)),
 }
 
-func actionWithCancel(fn func(ctx context.Context, env Env, args []string, config *Config) error) actionWithConfig {
-	return func(env Env, args []string, config *Config) error {
-		ctx, cancel := context.WithCancel(context.Background())
-
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, os.Interrupt)
-
-		// cancel the context on Ctrl-C
-		go func() {
-			<-c
-			cancel()
-		}()
-
-		return fn(ctx, env, args, config)
-	}
-}
-
-func exportCommand(ctx context.Context, env Env, args []string, config *Config) (err error) {
+func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 	defer log.SetPrefix(log.Prefix())
 	log.SetPrefix(log.Prefix() + "export:")
 	logDebug("start")
-
-	ec := ExportContext{
-		env:    env,
-		config: config,
-	}
 
 	var target string
 
@@ -58,103 +33,69 @@ func exportCommand(ctx context.Context, env Env, args []string, config *Config) 
 	}
 
 	logDebug("loading RCs")
-	if ec.getRCs(); !ec.hasRC() {
-		return nil
+	loadedRC := config.LoadedRC()
+	toLoad := findUp(config.WorkDir, ".envrc")
+
+	if loadedRC == nil && toLoad == "" {
+		return
 	}
 
 	logDebug("updating RC")
-	if err = ec.updateRC(ctx); err != nil {
-		logDebug("err: %v", err)
-	}
-
-	if ec.newEnv == nil {
-		logDebug("newEnv nil, exiting")
-		return
-	}
-
-	diffString := ec.diffString(shell)
-	logDebug("env diff %s", diffString)
-	fmt.Print(diffString)
-
-	return
-}
-
-// ExportContext is a sort of state holder struct that is being used to
-// record changes before the export finishes.
-type ExportContext struct {
-	config   *Config
-	foundRC  *RC
-	loadedRC *RC
-	env      Env
-	oldEnv   Env
-	newEnv   Env
-}
-
-func (ec *ExportContext) getRCs() {
-	ec.loadedRC = ec.config.LoadedRC()
-	ec.foundRC, _ = ec.config.FindRC()
-}
-
-func (ec *ExportContext) hasRC() bool {
-	return ec.foundRC != nil || ec.loadedRC != nil
-}
-
-func (ec *ExportContext) updateRC(ctx context.Context) (err error) {
-	defer log.SetPrefix(log.Prefix())
 	log.SetPrefix(log.Prefix() + "update:")
 
-	ec.oldEnv = ec.env.Copy()
+	logDebug("Determining action:")
+	logDebug("toLoad: %#v", toLoad)
+	logDebug("loadedRC: %#v", loadedRC)
 
-	var backupDiff *EnvDiff
-	if backupDiff, err = ec.config.EnvDiff(); err == nil && backupDiff != nil {
-		ec.oldEnv = backupDiff.Reverse().Patch(ec.env)
-	}
-	if err != nil {
-		err = fmt.Errorf("EnvDiff() failed: %q", err)
+	switch {
+	case toLoad == "":
+		logDebug("no RC found, unloading")
+	case loadedRC == nil:
+		logDebug("no RC (implies no DIRENV_DIFF),loading")
+	case loadedRC.path != toLoad:
+		logDebug("new RC, loading")
+	case loadedRC.times.Check() != nil:
+		logDebug("file changed, reloading")
+	default:
+		logDebug("no update needed")
 		return
 	}
 
-	logDebug("Determining action:")
-	logDebug("foundRC: %#v", ec.foundRC)
-	logDebug("loadedRC: %#v", ec.loadedRC)
+	var previousEnv, newEnv Env
 
-	switch {
-	case ec.foundRC == nil:
-		logDebug("no RC found, unloading")
-		ec.unloadEnv()
-	case ec.loadedRC == nil:
-		logDebug("no RC (implies no DIRENV_DIFF),loading")
-		err = ec.loadRC(ctx)
-	case ec.loadedRC.path != ec.foundRC.path:
-		logDebug("new RC, loading")
-		err = ec.loadRC(ctx)
-	case ec.loadedRC.times.Check() != nil:
-		logDebug("file changed, reloading")
-		err = ec.loadRC(ctx)
-	default:
-		logDebug("no update needed")
+	if previousEnv, err = config.Revert(currentEnv); err != nil {
+		err = fmt.Errorf("Revert() failed: %q", err)
+		logDebug("err: %v", err)
+		return
 	}
 
+	if toLoad == "" {
+		logStatus(currentEnv, "unloading")
+		newEnv = previousEnv.Copy()
+		newEnv.CleanContext()
+	} else {
+		newEnv, err = config.EnvFromRC(toLoad, previousEnv)
+		if err != nil {
+			logDebug("err: %v", err)
+			return
+		} else if newEnv == nil {
+			logDebug("newEnv nil, exiting")
+			return
+		}
+	}
+
+	if out := diffStatus(previousEnv.Diff(newEnv)); out != "" {
+		logStatus(currentEnv, "export %s", out)
+	}
+
+	diffString := currentEnv.Diff(newEnv).ToShell(shell)
+	logDebug("env diff %s", diffString)
+	fmt.Print(diffString)
 	return
 }
 
-func (ec *ExportContext) loadRC(ctx context.Context) (err error) {
-	ec.newEnv, err = ec.foundRC.Load(ctx, ec.config, ec.oldEnv)
-	return
-}
-
-func (ec *ExportContext) unloadEnv() {
-	logStatus(ec.env, "unloading")
-	ec.newEnv = ec.oldEnv.Copy()
-	cleanEnv(ec.newEnv)
-}
-
-func cleanEnv(env Env) {
-	env.CleanContext()
-}
-
-func (ec *ExportContext) diffString(shell Shell) string {
-	oldDiff := ec.oldEnv.Diff(ec.newEnv)
+// Return a string of +/-/~ indicators of an environment diff
+func diffStatus(oldDiff *EnvDiff) string {
 	if oldDiff.Any() {
 		var out []string
 		for key := range oldDiff.Prev {
@@ -177,13 +118,9 @@ func (ec *ExportContext) diffString(shell Shell) string {
 		}
 
 		sort.Strings(out)
-		if len(out) > 0 {
-			logStatus(ec.env, "export %s", strings.Join(out, " "))
-		}
+		return strings.Join(out, " ")
 	}
-
-	diff := ec.env.Diff(ec.newEnv)
-	return diff.ToShell(shell)
+	return ""
 }
 
 func direnvKey(key string) bool {

--- a/config.go
+++ b/config.go
@@ -182,15 +182,29 @@ func (config *Config) LoadedRC() *RC {
 	return RCFromEnv(rcPath, timesString, config)
 }
 
+// EnvFromRC loads an RC from a specified path and returns the new environment
+func (config *Config) EnvFromRC(path string, previousEnv Env) (Env, error) {
+	if rc, err := RCFromPath(path, config); err != nil {
+		return nil, err
+	} else {
+		return rc.Load(previousEnv)
+	}
+}
+
 // FindRC looks for a RC file in the config environment
 func (config *Config) FindRC() (*RC, error) {
 	return FindRC(config.WorkDir, config)
 }
 
-// EnvDiff returns the recorded environment diff that was stored if any.
-func (config *Config) EnvDiff() (*EnvDiff, error) {
+// Revert undoes the recorded changes (if any) to the supplied environment,
+// returning a new environment
+func (config *Config) Revert(env Env) (oldEnv Env, err error) {
 	if config.Env[DIRENV_DIFF] == "" {
-		return nil, nil
+		return env.Copy(), nil
 	}
-	return LoadEnvDiff(config.Env[DIRENV_DIFF])
+	if diff, err := LoadEnvDiff(config.Env[DIRENV_DIFF]); err == nil {
+		return diff.Reverse().Patch(env), nil
+	} else {
+		return nil, err
+	}
 }

--- a/config.go
+++ b/config.go
@@ -184,11 +184,11 @@ func (config *Config) LoadedRC() *RC {
 
 // EnvFromRC loads an RC from a specified path and returns the new environment
 func (config *Config) EnvFromRC(path string, previousEnv Env) (Env, error) {
-	if rc, err := RCFromPath(path, config); err != nil {
+	rc, err := RCFromPath(path, config)
+	if err != nil {
 		return nil, err
-	} else {
-		return rc.Load(previousEnv)
 	}
+	return rc.Load(previousEnv)
 }
 
 // FindRC looks for a RC file in the config environment
@@ -204,7 +204,6 @@ func (config *Config) Revert(env Env) (oldEnv Env, err error) {
 	}
 	if diff, err := LoadEnvDiff(config.Env[DIRENV_DIFF]); err == nil {
 		return diff.Reverse().Patch(env), nil
-	} else {
-		return nil, err
 	}
+	return nil, err
 }

--- a/config.go
+++ b/config.go
@@ -198,11 +198,12 @@ func (config *Config) FindRC() (*RC, error) {
 
 // Revert undoes the recorded changes (if any) to the supplied environment,
 // returning a new environment
-func (config *Config) Revert(env Env) (oldEnv Env, err error) {
+func (config *Config) Revert(env Env) (Env, error) {
 	if config.Env[DIRENV_DIFF] == "" {
 		return env.Copy(), nil
 	}
-	if diff, err := LoadEnvDiff(config.Env[DIRENV_DIFF]); err == nil {
+	diff, err := LoadEnvDiff(config.Env[DIRENV_DIFF])
+	if err == nil {
 		return diff.Reverse().Patch(env), nil
 	}
 	return nil, err


### PR DESCRIPTION
The previous logic flow for export was highly non-linear and tightly state-coupled across multiple functions with side-effects, making it extremely hard to follow what was happening.

This refactoring linearizes the core logic of export, replacing struct members with simple local variables, and makes all the internal functions fully functional and side-effect free.  In addition, some duplicated high-level code and miscellaneous housekeeping from exec and export was moved into rc and config, further clarifying how both exec and export work.

You can now see how the various env values are reverted, diffed, patched, etc. in one screenful of code, without needing to search through multiple functions trying to figure out who was doing what to whom in which order.  This should make it easier to plan out the changes for better Windows support, and hopefully make other maintenance easier as well.

Last, but not least, there is a slight performance improvement in that export no longer does redundant timestamp processing or content hashing when neither the existing path nor timestamps have changed.  (This duplication was easy to spot and fix after the main refactoring was done, suggesting that maintenance has already become a little easier. :wink:)

(By the way, given the amount of deleted code and re-organization, you will probably find the diffs for cmd_exec and cmd_export *much* easier to review in side-by-side mode rather than unified.  Or better yet, just read the new versions directly!)