### PR TITLE
man: regenerate direnv-stdlib.1 and direnv.toml.1

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -225,6 +225,10 @@ A semantic dispatch used to describe common project layouts.
 .PP
 Sets the GOPATH environment variable to the current directory.
 
+.SS \fB\fClayout julia\fR
+.PP
+Sets the \fB\fCJULIA\_PROJECT\fR environment variable to the current directory.
+
 .SS \fB\fClayout node\fR
 .PP
 Adds "$PWD/node\_modules/.bin" to the PATH environment variable.

--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -84,6 +84,8 @@ prefix = [ "/home/user/code/project\-a" ]
 
 .PP
 In this example, the following .envrc files will be implicitly allowed:
+
+.RS
 .IP \(bu 2
 \fB\fC/home/user/code/project\-a/.envrc\fR
 .IP \(bu 2
@@ -91,12 +93,18 @@ In this example, the following .envrc files will be implicitly allowed:
 .IP \(bu 2
 and so on
 
+.RE
+
 .PP
 In this example, the following .envrc files will not be implicitly allowed (although they can be explicitly allowed by running \fB\fCdirenv allow\fR):
+
+.RS
 .IP \(bu 2
 \fB\fC/home/user/project\-b/.envrc\fR
 .IP \(bu 2
 \fB\fC/opt/random/.envrc\fR
+
+.RE
 
 .SS \fB\fCexact\fR
 .PP
@@ -117,17 +125,25 @@ exact = [ "/home/user/project\-b/.envrc", "/home/user/project\-b/subdir\-a" ]
 
 .PP
 In this example, the following .envrc files will be implicitly allowed, and no others:
+
+.RS
 .IP \(bu 2
 \fB\fC/home/user/code/project\-b/.envrc\fR
 .IP \(bu 2
 \fB\fC/home/user/code/project\-b/subdir\-a\fR
 
+.RE
+
 .PP
 In this example, the following .envrc files will not be implicitly allowed (although they can be explicitly allowed by running \fB\fCdirenv allow\fR):
+
+.RS
 .IP \(bu 2
 \fB\fC/home/user/code/project\-b/subproject\-c/.envrc\fR
 .IP \(bu 2
 \fB\fC/home/user/code/.envrc\fR
+
+.RE
 
 .SH COPYRIGHT
 .PP


### PR DESCRIPTION
Missed this in https://github.com/direnv/direnv/pull/661

Is there a reason these auto-generated files are included in the repo at all? Seems like the `man/*.1` pages, and `stdlib.go` could just be `.gitignored`?