### PR TITLE
stdlib: use_julia <version>

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -307,6 +307,28 @@ use ruby 1.9.3
 .fi
 .RE
 
+.SS \fB\fCuse julia <version>\fR
+.PP
+Loads the specified Julia version. You must specify a path to the directory with
+installed Julia versions using $JULIA\_VERSIONS. You can optionally override the
+prefix for folders inside $JULIA\_VERSIONS (default \fB\fCjulia\-\fR) using $JULIA\_VERSION\_PREFIX.
+If no exact match for \fB\fC<version>\fR is found a search will be performed and the latest
+version will be loaded.
+
+.PP
+Examples (.envrc):
+
+.PP
+.RS
+
+.nf
+use julia 1.5.1   # loads $JULIA\_VERSIONS/julia\-1.5.1
+use julia 1.5     # loads $JULIA\_VERSIONS/julia\-1.5.1
+use julia master  # loads $JULIA\_VERSIONS/julia\-master
+
+.fi
+.RE
+
 .SS \fB\fCuse rbenv\fR
 .PP
 Loads rbenv which add the ruby wrappers available on the PATH.

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -221,6 +221,20 @@ Example:
     use ruby 1.9.3
     # output: Ruby 1.9.3
 
+### `use julia <version>`
+
+Loads the specified Julia version. You must specify a path to the directory with
+installed Julia versions using $JULIA_VERSIONS. You can optionally override the
+prefix for folders inside $JULIA_VERSIONS (default `julia-`) using $JULIA_VERSION_PREFIX.
+If no exact match for `<version>` is found a search will be performed and the latest
+version will be loaded.
+
+Examples (.envrc):
+
+    use julia 1.5.1   # loads $JULIA_VERSIONS/julia-1.5.1
+    use julia 1.5     # loads $JULIA_VERSIONS/julia-1.5.1
+    use julia master  # loads $JULIA_VERSIONS/julia-master
+
 ### `use rbenv`
 
 Loads rbenv which add the ruby wrappers available on the PATH.

--- a/stdlib.go
+++ b/stdlib.go
@@ -770,6 +770,50 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  \"use_$cmd\" \"$@\"\n" +
 	"}\n" +
 	"\n" +
+	"# Usage: use julia [<version>]\n" +
+	"# Loads specified Julia version.\n" +
+	"#\n" +
+	"# Environment Variables:\n" +
+	"#\n" +
+	"# - $JULIA_VERSIONS (required)\n" +
+	"#   You must specify a path to your installed Julia versions with the `$JULIA_VERSIONS` variable.\n" +
+	"#\n" +
+	"# - $JULIA_VERSION_PREFIX (optional) [default=\"julia-\"]\n" +
+	"#   Overrides the default version prefix.\n" +
+	"#\n" +
+	"use_julia() {\n" +
+	"  local version=${1:-}\n" +
+	"  local julia_version_prefix=${JULIA_VERSION_PREFIX:-julia-}\n" +
+	"  local search_version\n" +
+	"  local julia_prefix\n" +
+	"\n" +
+	"  if [[ -z ${JULIA_VERSIONS:-} || -z $version ]]; then\n" +
+	"    log_error \"Must specify the \\$JULIA_VERSIONS environment variable and a Julia version!\"\n" +
+	"    return 1\n" +
+	"  fi\n" +
+	"\n" +
+	"  julia_prefix=\"${JULIA_VERSIONS}/${julia_version_prefix}${version}\"\n" +
+	"\n" +
+	"  if [[ ! -d ${julia_prefix} ]]; then\n" +
+	"    search_version=$(semver_search \"${JULIA_VERSIONS}\" \"${julia_version_prefix}\" \"${version}\")\n" +
+	"    julia_prefix=\"${JULIA_VERSIONS}/${julia_version_prefix}${search_version}\"\n" +
+	"  fi\n" +
+	"\n" +
+	"  if [[ ! -d $julia_prefix ]]; then\n" +
+	"    log_error \"Unable to find Julia version ($version) in ($JULIA_VERSIONS)!\"\n" +
+	"    return 1\n" +
+	"  fi\n" +
+	"\n" +
+	"  if [[ ! -x $julia_prefix/bin/julia ]]; then\n" +
+	"    log_error \"Unable to load Julia binary (julia) for version ($version) in ($JULIA_VERSIONS)!\"\n" +
+	"    return 1\n" +
+	"  fi\n" +
+	"\n" +
+	"  load_prefix \"$julia_prefix\"\n" +
+	"\n" +
+	"  log_status \"Successfully loaded $(julia --version), from prefix ($julia_prefix)\"\n" +
+	"}\n" +
+	"\n" +
 	"# Usage: use rbenv\n" +
 	"#\n" +
 	"# Loads rbenv which add the ruby wrappers available on the PATH.\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -767,6 +767,50 @@ use() {
   "use_$cmd" "$@"
 }
 
+# Usage: use julia [<version>]
+# Loads specified Julia version.
+#
+# Environment Variables:
+#
+# - $JULIA_VERSIONS (required)
+#   You must specify a path to your installed Julia versions with the `$JULIA_VERSIONS` variable.
+#
+# - $JULIA_VERSION_PREFIX (optional) [default="julia-"]
+#   Overrides the default version prefix.
+#
+use_julia() {
+  local version=${1:-}
+  local julia_version_prefix=${JULIA_VERSION_PREFIX:-julia-}
+  local search_version
+  local julia_prefix
+
+  if [[ -z ${JULIA_VERSIONS:-} || -z $version ]]; then
+    log_error "Must specify the \$JULIA_VERSIONS environment variable and a Julia version!"
+    return 1
+  fi
+
+  julia_prefix="${JULIA_VERSIONS}/${julia_version_prefix}${version}"
+
+  if [[ ! -d ${julia_prefix} ]]; then
+    search_version=$(semver_search "${JULIA_VERSIONS}" "${julia_version_prefix}" "${version}")
+    julia_prefix="${JULIA_VERSIONS}/${julia_version_prefix}${search_version}"
+  fi
+
+  if [[ ! -d $julia_prefix ]]; then
+    log_error "Unable to find Julia version ($version) in ($JULIA_VERSIONS)!"
+    return 1
+  fi
+
+  if [[ ! -x $julia_prefix/bin/julia ]]; then
+    log_error "Unable to load Julia binary (julia) for version ($version) in ($JULIA_VERSIONS)!"
+    return 1
+  fi
+
+  load_prefix "$julia_prefix"
+
+  log_status "Successfully loaded $(julia --version), from prefix ($julia_prefix)"
+}
+
 # Usage: use rbenv
 #
 # Loads rbenv which add the ruby wrappers available on the PATH.


### PR DESCRIPTION
Note: This is pending https://github.com/direnv/direnv/pull/665 which I factored out from this branch to simplify reviewing.

`stdlib`: new function `use_julia` that loads the specified julia version. The implementation is similar to `use_node`. In particular it requires the user to specify the directory with installations with `$JULIA_VERSIONS` and for partial versions a `semver_search` is performed.

Edit: 1cfc446a9a6e9cc18d448a8167524e841f98e787 is the commit to review for this PR, the rest are autogenerated changes or changes to review in https://github.com/direnv/direnv/pull/665.

