### PR TITLE
stdlib/use_julia: fix a bug in parameter substitution

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -783,7 +783,7 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"#\n" +
 	"use_julia() {\n" +
 	"  local version=${1:-}\n" +
-	"  local julia_version_prefix=${JULIA_VERSION_PREFIX:-julia-}\n" +
+	"  local julia_version_prefix=${JULIA_VERSION_PREFIX-julia-}\n" +
 	"  local search_version\n" +
 	"  local julia_prefix\n" +
 	"\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -780,7 +780,7 @@ use() {
 #
 use_julia() {
   local version=${1:-}
-  local julia_version_prefix=${JULIA_VERSION_PREFIX:-julia-}
+  local julia_version_prefix=${JULIA_VERSION_PREFIX-julia-}
   local search_version
   local julia_prefix
 


### PR DESCRIPTION
The first commit fixes some complaints when running with `-u` as is done in the tests:
```
stdlib.sh:354: !1: unbound variable
```
and
```
stdlib.sh:359: path_array[@]: unbound variable
```
The fix for the array expansion is taken from https://stackoverflow.com/a/61551944/5087136 which suggests this fix as the "only safe idiom". I am not 100% sure about this first commit, so please review carefully!


The second commit is just a stupid bug fix -- the empty version prefix should of course be used, just like https://github.com/direnv/direnv/blob/98033c305ef2fdd3eb7ad5a83974c24da8becd15/stdlib.sh#L861. Also adds tests to `use julia` (which is what prompted the first commit, since `path_add` errors otherwise).
