### PR TITLE
stdlib: use Bash 3.0-compatible array expansion

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -354,12 +354,12 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  local path i var_name=\"$1\"\n" +
 	"  # split existing paths into an array\n" +
 	"  declare -a path_array\n" +
-	"  IFS=: read -ra path_array <<<\"${!1}\"\n" +
+	"  IFS=: read -ra path_array <<<\"${!1-}\"\n" +
 	"  shift\n" +
 	"\n" +
 	"  # prepend the passed paths in the right order\n" +
 	"  for ((i = $#; i > 0; i--)); do\n" +
-	"    path_array=(\"$(expand_path \"${!i}\")\" \"${path_array[@]}\")\n" +
+	"    path_array=(\"$(expand_path \"${!i}\")\" ${path_array[@]+\"${path_array[@]}\"})\n" +
 	"  done\n" +
 	"\n" +
 	"  # join back all the paths\n" +
@@ -422,9 +422,9 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  results=()\n" +
 	"\n" +
 	"  # iterate over path entries, discard entries that match any of the patterns\n" +
-	"  for path in \"${path_array[@]}\"; do\n" +
+	"  for path in ${path_array[@]+\"${path_array[@]}\"}; do\n" +
 	"    discard=false\n" +
-	"    for pattern in \"${patterns[@]}\"; do\n" +
+	"    for pattern in ${patterns[@]+\"${patterns[@]}\"}; do\n" +
 	"      if [[ \"$path\" == +($pattern) ]]; then\n" +
 	"        discard=true\n" +
 	"        break\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -351,12 +351,12 @@ path_add() {
   local path i var_name="$1"
   # split existing paths into an array
   declare -a path_array
-  IFS=: read -ra path_array <<<"${!1}"
+  IFS=: read -ra path_array <<<"${!1-}"
   shift
 
   # prepend the passed paths in the right order
   for ((i = $#; i > 0; i--)); do
-    path_array=("$(expand_path "${!i}")" "${path_array[@]}")
+    path_array=("$(expand_path "${!i}")" ${path_array[@]+"${path_array[@]}"})
   done
 
   # join back all the paths
@@ -419,9 +419,9 @@ path_rm() {
   results=()
 
   # iterate over path entries, discard entries that match any of the patterns
-  for path in "${path_array[@]}"; do
+  for path in ${path_array[@]+"${path_array[@]}"}; do
     discard=false
-    for pattern in "${patterns[@]}"; do
+    for pattern in ${patterns[@]+"${patterns[@]}"}; do
       if [[ "$path" == +($pattern) ]]; then
         discard=true
         break


### PR DESCRIPTION
When `set -u` is being used, Bash 3.0 tracks empty array as unused
variables.

There is a big table of compatible versions, with each their own errors:
https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u/61551944#61551944

Thanks to @fredrikekre for finding the root cause.

Fixes #675