### PR TITLE
Clarify path to direnv.toml

### DIFF
--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -9,7 +9,7 @@ direnv.toml - the direnv configuration file
 DESCRIPTION
 -----------
 
-A configuration file in [TOML](https://github.com/toml-lang/toml) format to specify a variety of configuration options for direnv. Resides at CONFIGURATION_DIR/direnv.toml. For many users, this will be located at $HOME/.config/direnv/direnv.toml.
+A configuration file in [TOML](https://github.com/toml-lang/toml) format to specify a variety of configuration options for direnv. Read from at CONFIGURATION_DIR/direnv.toml or $DIRENV_CONFIG/direnv.toml. For many users, CONFIGURATION_DIR will be located at $HOME/.config/direnv/direnv.toml.
 
 FORMAT
 ------


### PR DESCRIPTION
From the documentation it wasn't quite clear where the `direnv.toml` was
being sourced from.