### PR TITLE
Look for stdlib in DIRENV_CONFIG

### DIFF
--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -6,7 +6,7 @@ direnv.toml \- the direnv configuration file
 .SH DESCRIPTION
 .PP
 A configuration file in TOML
-\[la]https://github.com/toml-lang/toml\[ra] format to specify a variety of configuration options for direnv. Resides at CONFIGURATION\_DIR/direnv.toml. For many users, this will be located at $HOME/.config/direnv/direnv.toml.
+\[la]https://github.com/toml-lang/toml\[ra] format to specify a variety of configuration options for direnv. Read from at CONFIGURATION\_DIR/direnv.toml or $DIRENV\_CONFIG/direnv.toml. For many users, CONFIGURATION\_DIR will be located at $HOME/.config/direnv/direnv.toml.
 
 .SH FORMAT
 .PP
@@ -84,8 +84,6 @@ prefix = [ "/home/user/code/project\-a" ]
 
 .PP
 In this example, the following .envrc files will be implicitly allowed:
-
-.RS
 .IP \(bu 2
 \fB\fC/home/user/code/project\-a/.envrc\fR
 .IP \(bu 2
@@ -93,18 +91,12 @@ In this example, the following .envrc files will be implicitly allowed:
 .IP \(bu 2
 and so on
 
-.RE
-
 .PP
 In this example, the following .envrc files will not be implicitly allowed (although they can be explicitly allowed by running \fB\fCdirenv allow\fR):
-
-.RS
 .IP \(bu 2
 \fB\fC/home/user/project\-b/.envrc\fR
 .IP \(bu 2
 \fB\fC/opt/random/.envrc\fR
-
-.RE
 
 .SS \fB\fCexact\fR
 .PP
@@ -125,25 +117,17 @@ exact = [ "/home/user/project\-b/.envrc", "/home/user/project\-b/subdir\-a" ]
 
 .PP
 In this example, the following .envrc files will be implicitly allowed, and no others:
-
-.RS
 .IP \(bu 2
 \fB\fC/home/user/code/project\-b/.envrc\fR
 .IP \(bu 2
 \fB\fC/home/user/code/project\-b/subdir\-a\fR
 
-.RE
-
 .PP
 In this example, the following .envrc files will not be implicitly allowed (although they can be explicitly allowed by running \fB\fCdirenv allow\fR):
-
-.RS
 .IP \(bu 2
 \fB\fC/home/user/code/project\-b/subproject\-c/.envrc\fR
 .IP \(bu 2
 \fB\fC/home/user/code/.envrc\fR
-
-.RE
 
 .SH COPYRIGHT
 .PP

--- a/stdlib.go
+++ b/stdlib.go
@@ -23,7 +23,7 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"DIRENV_LOG_FORMAT=\"${DIRENV_LOG_FORMAT-direnv: %s}\"\n" +
 	"\n" +
 	"# Where direnv configuration should be stored\n" +
-	"direnv_config_dir=${XDG_CONFIG_HOME:-$HOME/.config}/direnv\n" +
+	"direnv_config_dir=\"${DIRENV_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/direnv}\"\n" +
 	"\n" +
 	"# This variable can be used by programs to detect when they are running inside\n" +
 	"# of a .envrc evaluation context. It is ignored by the direnv diffing\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -20,7 +20,7 @@ direnv="$(command -v direnv)"
 DIRENV_LOG_FORMAT="${DIRENV_LOG_FORMAT-direnv: %s}"
 
 # Where direnv configuration should be stored
-direnv_config_dir=${XDG_CONFIG_HOME:-$HOME/.config}/direnv
+direnv_config_dir="${DIRENV_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/direnv}"
 
 # This variable can be used by programs to detect when they are running inside
 # of a .envrc evaluation context. It is ignored by the direnv diffing


### PR DESCRIPTION
Closes #677 

This updates the `stdlib` to look for `direnvrc` and `lib/*.sh` in
`$DIRENV_CONFIG` first, then `$XDG_CONFIG_DATA/direnv`, and finally
`$HOME/.config/direnv`.

Few notes:
* I forgot to run `make` in #678 
* The `XDG_CONFIG_DATA` bit is not mentioned in the README (though `$HOME/.config` is) so I haven't documented the `$DIRENV_CONFIG` mechanism either. Happy to amend.