### PR TITLE
shell: Update Elvish hook to replace deprecated `explode`

### DIFF
--- a/shell_elvish.go
+++ b/shell_elvish.go
@@ -16,7 +16,7 @@ func (elvish) Hook() (string, error) {
 	try {
 		m = [("{{.SelfPath}}" export elvish | from-json)]
 		if (> (count $m) 0) {
-			m = (explode $m)
+			m = (all $m)
 			keys $m | each [k]{
 				if $m[$k] {
 					set-env $k $m[$k]


### PR DESCRIPTION
https://elv.sh/blog/0.14.0-release-notes.html

I haven't manually tested this on Elvish 0.12 but was at least able to confirm that the `all` builtin exists in that version.

Without this change, opening a new shell results in a deprecation warning like the following:

```
deprecation: the "explode" command is deprecated; use "all" instead
/Users/USERNAME/.elvish/lib/direnv.elv, line 6: 			m = (explode $m)
```