### PR TITLE
fix: use restored env in exec

### DIFF
--- a/cmd_exec.go
+++ b/cmd_exec.go
@@ -57,7 +57,7 @@ func cmdExecAction(env Env, args []string, config *Config) (err error) {
 			return
 		}
 	} else {
-		newEnv = env
+		newEnv = previousEnv
 	}
 
 	var commandPath string


### PR DESCRIPTION
Currently, when running `direnv exec <dir> <command>`, the environment is not restored unless there is a `.envrc` file in or above `<dir>`. This PR ensures that the environment is also restored when no `.envrc` file is present in or above `<dir>`.

See #383 for a test case. Assuming that there is no `.envrc` in `~` or `~/tmp`, without this PR:

```
~/tmp/foo❯ direnv exec .. ../check
FOO: foo
BAR:
~/tmp/foo❯ direnv exec ../bar ../check
FOO:
BAR: bar
```

The expected output occurs when `<dir>` is `../bar`, because `../bar` contains a `.envrc`. However, when `<dir>` is `..`, where there is no `.envrc`, the environment is not properly restored.

With this PR:

```
~/tmp/foo❯ direnv exec .. ../check
FOO:
BAR:
~/tmp/foo❯ direnv exec ../bar ../check
FOO:
BAR: bar
```

resolves #383