### PR TITLE
fix: handle links on Mac when using `allow`

### DIFF
--- a/cmd_allow.go
+++ b/cmd_allow.go
@@ -25,7 +25,12 @@ being moved to XDG_DATA_HOME.
 func cmdAllowAction(env Env, args []string, config *Config) (err error) {
 	var rcPath string
 	if len(args) > 1 {
-		rcPath = args[1]
+		if rcPath, err = filepath.Abs(args[1]); err != nil {
+			return err
+		}
+		if rcPath, err = filepath.EvalSymlinks(rcPath); err != nil {
+			return err
+		}
 	} else {
 		if rcPath, err = os.Getwd(); err != nil {
 			return err


### PR DESCRIPTION
At least on macOS, paths passed to `direnv allow <dir>` weren't being fully resolved during the `allow` process. For example, `direnv allow /tmp/dir` would store an authorization for /tmp/dir/.envrc. On Macs, /tmp is an alias for /private/tmp, and when the user actually cd-ed into /tmp/dir, the path provided by os.Getwd would be /private/tmp/dir, which resulted in a different hash.

Aliases aren't symlinks, but go's `EvalSymlinks` resolves them anyway.

Both the `Abs` and `EvalSymlinks` calls are required, as `Abs` doesn't resolve links and `EvalSymlinks` doesn't resolve relative paths.

resolves #694