### PR TITLE
Introduce on_branch to stdlib

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1012,3 +1012,33 @@ __main__() {
   # and finally load the .envrc
   "$@"
 }
+
+# Usage: on_branch [<branch_name>]
+#
+# Returns 0 if within a git repository with the given branch name. If no branch
+# name is provided, then returns 0 when within _any_ branch.
+# Returns 1 otherwise.
+#
+# When a branch is specified, git's index is watched so that entering/exiting
+# branches triggers a reload.
+#
+# Example:
+#
+#    if on_branch develop; then
+#      echo "Remember to merge with upstream regularly!";
+#    fi
+#
+#    if on_branch; then
+#      echo "Thanks for contributing to a GitHub project!"
+#    fi
+#
+on_branch() {
+  local git_dir
+  git_dir=$(git rev-parse --git-dir 2> /dev/null)
+  if [[ $? -eq 0 ]] && [[ -f $git_dir/index ]]; then
+    [ ! -z "$1" ] && watch_file "$git_dir/index"
+  else
+    return 1
+  fi
+  [ -z "$1" ] || [ "$(git branch --show-current)" = "$1" ]
+}


### PR DESCRIPTION
When working on GitHub projects, I've found it helpful to have env variables set-up when I'm inside a specific branch. For example, sometimes I want to change the merge-base my editor uses to display signifiers. I can accomplish this with the new predicate like so:

```bash
if on_branch sub_branch; then
  export MERGE_BASE_BRANCH=super_branch
fi
```

To detect exiting the branch, I watch the git repository's index file (`.git/index`) with `watch_file`. This tends to be noisy sometimes, because it triggers even when the branch _doesn't_ change (e.g. when committing changes to the branch). Would love to learn about a "smarter" way to detect branch changes!