### PR TITLE
rc: make file existence check more robust

### DIFF
--- a/rc.go
+++ b/rc.go
@@ -239,8 +239,14 @@ func eachDir(path string) (paths []string) {
 }
 
 func fileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
+	// Some broken filesystems like SSHFS return file information on stat() but
+	// then cannot open the file. So we use os.Open instead.
+	f, err := os.Open(path)
+	if err == nil {
+		f.Close()
+		return true
+	}
+	return false
 }
 
 func fileHash(path string) (hash string, err error) {


### PR DESCRIPTION
Some broken filesystems like SSHFS return file information on stat() but
then cannot open the file. So we use os.Open instead.

Fixes #704