### PR TITLE
stdlib: add source_env_if_exists

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -101,6 +101,26 @@ Loads another \fB\fC\&.envrc\fR either by specifying its path or filename.
 .PP
 NOTE: the other \fB\fC\&.envrc\fR is not checked by the security framework.
 
+.SS \fB\fCsource\_env\_if\_exists <filename>\fR
+.PP
+Loads another ".envrc", but only if it exists.
+
+.PP
+NOTE: contrary to \fB\fCsource\_env\fR, this only works when passing a path to a file,
+      not a directory.
+
+.PP
+Example:
+
+.PP
+.RS
+
+.nf
+source\_env\_if\_exists .envrc.private
+
+.fi
+.RE
+
 .SS \fB\fCsource\_up [<filename>]\fR
 .PP
 Loads another \fB\fC\&.envrc\fR if found when searching from the parent directory up to /.

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -75,6 +75,17 @@ Loads another `.envrc` either by specifying its path or filename.
 
 NOTE: the other `.envrc` is not checked by the security framework.
 
+### `source_env_if_exists <filename>`
+
+Loads another ".envrc", but only if it exists.
+
+NOTE: contrary to `source_env`, this only works when passing a path to a file,
+      not a directory.
+
+Example:
+
+    source_env_if_exists .envrc.private
+
 ### `source_up [<filename>]`
 
 Loads another `.envrc` if found when searching from the parent directory up to /.

--- a/stdlib.go
+++ b/stdlib.go
@@ -254,6 +254,22 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  popd >/dev/null || return 1\n" +
 	"}\n" +
 	"\n" +
+	"# Usage: source_env_if_exists <filename>\n" +
+	"#\n" +
+	"# Loads another \".envrc\", but only if it exists.\n" +
+	"#\n" +
+	"# NOTE: contrary to source_env, this only works when passing a path to a file,\n" +
+	"#       not a directory.\n" +
+	"#\n" +
+	"# Example:\n" +
+	"# \n" +
+	"#    source_env_if_exists .envrc.private\n" +
+	"#\n" +
+	"source_env_if_exists() {\n" +
+	"  watch_file \"$1\"\n" +
+	"  if [[ -f \"$1\" ]]; then source_env \"$1\"; fi\n" +
+	"}\n" +
+	"\n" +
 	"# Usage: watch_file <filename> [<filename> ...]\n" +
 	"#\n" +
 	"# Adds each <filename> to the list of files that direnv will watch for changes -\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -251,6 +251,22 @@ source_env() {
   popd >/dev/null || return 1
 }
 
+# Usage: source_env_if_exists <filename>
+#
+# Loads another ".envrc", but only if it exists.
+#
+# NOTE: contrary to source_env, this only works when passing a path to a file,
+#       not a directory.
+#
+# Example:
+# 
+#    source_env_if_exists .envrc.private
+#
+source_env_if_exists() {
+  watch_file "$1"
+  if [[ -f "$1" ]]; then source_env "$1"; fi
+}
+
 # Usage: watch_file <filename> [<filename> ...]
 #
 # Adds each <filename> to the list of files that direnv will watch for changes -

--- a/test/stdlib.bash
+++ b/test/stdlib.bash
@@ -137,4 +137,22 @@ test_name use_julia
   test_julia ""    "1.5"
 )
 
+test_name source_env_if_exists
+(
+  load_stdlib
+
+  workdir=$(mktemp -d)
+  trap 'rm -rf "$workdir"' EXIT
+
+  cd "$workdir"
+
+  # Try to source a file that doesn't exist
+  source_env_if_exists non_existing_file
+
+  # Try to source a file that exists
+  echo "export FOO=bar" > existing_file
+  source_env_if_exists existing_file
+  [[ $FOO = bar ]]
+)
+
 echo OK


### PR DESCRIPTION
This allows to shorten a common pattern:

    source_env_if_exists .envrc.private