### PR TITLE
Added use_nodenv to stdlib

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -692,32 +692,6 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"#\n" +
 	"# Uses use_node and layout_node to add the chosen node version and \n" +
 	"# \"$PWD/node_modules/.bin\" to the PATH\n" +
-	"#\n" +
-	"# Usage: layout nodenv <node version number>\n" +
-	"#\n" +
-	"# Example:\n" +
-	"#\n" +
-	"#    layout nodenv 15.2.1\n" +
-	"#\n" +
-	"# Uses use_node and layout_node to add the chosen node version and \n" +
-	"# \"$PWD/node_modules/.bin\" to the PATH\n" +
-	"#\n" +
-	"layout_nodenv() {\n" +
-	"  local node_version=\"${1}\"\n" +
-	"  local node_versions\n" +
-	"  local nodenv_version\n" +
-	"  node_versions=\"$(nodenv root)/versions\"\n" +
-	"  nodenv_version=${node_versions}/${node_version}\n" +
-	"  if [[ -e \"$nodenv_version\" ]]; then\n" +
-	"      # Put the selected node version in the PATH\n" +
-	"      NODE_VERSIONS=\"${node_versions}\" NODE_VERSION_PREFIX=\"\" use_node \"${node_version}\"\n" +
-	"      # Add $PWD/node_modules/.bin to the PATH\n" +
-	"      layout_node\n" +
-	"  else\n" +
-	"    log_error \"nodenv: version '$node_version' not installed\"\n" +
-	"    return 1\n" +
-	"  fi\n" +
-	"}\n" +
 	"\n" +
 	"# Usage: layout perl\n" +
 	"#\n" +
@@ -1103,6 +1077,32 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"    log_status \"Successfully loaded NodeJS $(node --version), from prefix ($node_prefix)\"\n" +
 	"  else\n" +
 	"    log_status \"Successfully loaded NodeJS $(node --version) (via $via), from prefix ($node_prefix)\"\n" +
+	"  fi\n" +
+	"}\n" +
+	"\n" +
+	"# Usage: use nodenv <node version number>\n" +
+	"#\n" +
+	"# Example:\n" +
+	"#\n" +
+	"#    use nodenv 15.2.1\n" +
+	"#\n" +
+	"# Uses nodenv, use_node and layout_node to add the chosen node version and \n" +
+	"# \"$PWD/node_modules/.bin\" to the PATH\n" +
+	"#\n" +
+	"use_nodenv() {\n" +
+	"  local node_version=\"${1}\"\n" +
+	"  local node_versions_dir\n" +
+	"  local nodenv_version\n" +
+	"  node_versions_dir=\"$(nodenv root)/versions\"\n" +
+	"  nodenv_version=\"${node_versions_dir}/${node_version}\"\n" +
+	"  if [[ -e \"$nodenv_version\" ]]; then\n" +
+	"      # Put the selected node version in the PATH\n" +
+	"      NODE_VERSIONS=\"${node_versions_dir}\" NODE_VERSION_PREFIX=\"\" use_node \"${node_version}\"\n" +
+	"      # Add $PWD/node_modules/.bin to the PATH\n" +
+	"      layout_node\n" +
+	"  else\n" +
+	"    log_error \"nodenv: version '$node_version' not installed.  Use \\`nodenv install ${node_version}\\` to install it first.\"\n" +
+	"    return 1\n" +
 	"  fi\n" +
 	"}\n" +
 	"\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -684,6 +684,30 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  PATH_add node_modules/.bin\n" +
 	"}\n" +
 	"\n" +
+	"# Usage: layout nodenv <node version number>\n" +
+	"#\n" +
+	"# Example:\n" +
+	"#\n" +
+	"#    layout nodenv 15.2.1\n" +
+	"#\n" +
+	"# Uses use_node and layout_node to add the chosen node version and \n" +
+	"# \"$PWD/node_modules/.bin\" to the PATH\n" +
+	"#\n" +
+	"layout_nodenv() {\n" +
+	"  local node_version=\"${1}\"\n" +
+	"  local node_versions=\"$(nodenv root)/versions\"\n" +
+	"  local nodenv_version=${node_versions}/${node_version}\n" +
+	"  if [[ -e \"$nodenv_version\" ]]; then\n" +
+	"  	  # Put the selected node version in the PATH\n" +
+	"      NODE_VERSIONS=\"${node_versions}\" NODE_VERSION_PREFIX=\"\" use_node $node_version\n" +
+	"      # Add $PWD/node_modules/.bin to the PATH\n" +
+	"      layout_node\n" +
+	"  else\n" +
+	"    log_error \"nodenv: version '$node_version' not installed\"\n" +
+	"    return 1\n" +
+	"  fi\n" +
+	"}\n" +
+	"\n" +
 	"# Usage: layout perl\n" +
 	"#\n" +
 	"# Setup environment variables required by perl's local::lib\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -684,15 +684,6 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  PATH_add node_modules/.bin\n" +
 	"}\n" +
 	"\n" +
-	"# Usage: layout nodenv <node version number>\n" +
-	"#\n" +
-	"# Example:\n" +
-	"#\n" +
-	"#    layout nodenv 15.2.1\n" +
-	"#\n" +
-	"# Uses use_node and layout_node to add the chosen node version and \n" +
-	"# \"$PWD/node_modules/.bin\" to the PATH\n" +
-	"\n" +
 	"# Usage: layout perl\n" +
 	"#\n" +
 	"# Setup environment variables required by perl's local::lib\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -693,13 +693,24 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"# Uses use_node and layout_node to add the chosen node version and \n" +
 	"# \"$PWD/node_modules/.bin\" to the PATH\n" +
 	"#\n" +
+	"# Usage: layout nodenv <node version number>\n" +
+	"#\n" +
+	"# Example:\n" +
+	"#\n" +
+	"#    layout nodenv 15.2.1\n" +
+	"#\n" +
+	"# Uses use_node and layout_node to add the chosen node version and \n" +
+	"# \"$PWD/node_modules/.bin\" to the PATH\n" +
+	"#\n" +
 	"layout_nodenv() {\n" +
 	"  local node_version=\"${1}\"\n" +
-	"  local node_versions=\"$(nodenv root)/versions\"\n" +
-	"  local nodenv_version=${node_versions}/${node_version}\n" +
+	"  local node_versions\n" +
+	"  local nodenv_version\n" +
+	"  node_versions=\"$(nodenv root)/versions\"\n" +
+	"  nodenv_version=${node_versions}/${node_version}\n" +
 	"  if [[ -e \"$nodenv_version\" ]]; then\n" +
-	"  	  # Put the selected node version in the PATH\n" +
-	"      NODE_VERSIONS=\"${node_versions}\" NODE_VERSION_PREFIX=\"\" use_node $node_version\n" +
+	"      # Put the selected node version in the PATH\n" +
+	"      NODE_VERSIONS=\"${node_versions}\" NODE_VERSION_PREFIX=\"\" use_node \"${node_version}\"\n" +
 	"      # Add $PWD/node_modules/.bin to the PATH\n" +
 	"      layout_node\n" +
 	"  else\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -687,6 +687,30 @@ layout_node() {
   PATH_add node_modules/.bin
 }
 
+# Usage: layout nodenv <node version number>
+#
+# Example:
+#
+#    layout nodenv 15.2.1
+#
+# Uses use_node and layout_node to add the chosen node version and 
+# "$PWD/node_modules/.bin" to the PATH
+#
+layout_nodenv() {
+  local node_version="${1}"
+  local node_versions="$(nodenv root)/versions"
+  local nodenv_version=${node_versions}/${node_version}
+  if [[ -e "$nodenv_version" ]]; then
+      # Put the selected node version in the PATH
+      NODE_VERSIONS="${node_versions}" NODE_VERSION_PREFIX="" use_node $node_version
+      # Add $PWD/node_modules/.bin to the PATH
+      layout_node
+  else
+    log_error "nodenv: version '$node_version' not installed"
+    return 1
+  fi
+}
+
 # Usage: layout perl
 #
 # Setup environment variables required by perl's local::lib

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -698,11 +698,13 @@ layout_node() {
 #
 layout_nodenv() {
   local node_version="${1}"
-  local node_versions="$(nodenv root)/versions"
-  local nodenv_version=${node_versions}/${node_version}
+  local node_versions
+  local nodenv_version
+  node_versions="$(nodenv root)/versions"
+  nodenv_version=${node_versions}/${node_version}
   if [[ -e "$nodenv_version" ]]; then
       # Put the selected node version in the PATH
-      NODE_VERSIONS="${node_versions}" NODE_VERSION_PREFIX="" use_node $node_version
+      NODE_VERSIONS="${node_versions}" NODE_VERSION_PREFIX="" use_node "${node_version}"
       # Add $PWD/node_modules/.bin to the PATH
       layout_node
   else

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -687,32 +687,6 @@ layout_node() {
   PATH_add node_modules/.bin
 }
 
-# Usage: layout nodenv <node version number>
-#
-# Example:
-#
-#    layout nodenv 15.2.1
-#
-# Uses use_node and layout_node to add the chosen node version and 
-# "$PWD/node_modules/.bin" to the PATH
-#
-layout_nodenv() {
-  local node_version="${1}"
-  local node_versions
-  local nodenv_version
-  node_versions="$(nodenv root)/versions"
-  nodenv_version=${node_versions}/${node_version}
-  if [[ -e "$nodenv_version" ]]; then
-      # Put the selected node version in the PATH
-      NODE_VERSIONS="${node_versions}" NODE_VERSION_PREFIX="" use_node "${node_version}"
-      # Add $PWD/node_modules/.bin to the PATH
-      layout_node
-  else
-    log_error "nodenv: version '$node_version' not installed"
-    return 1
-  fi
-}
-
 # Usage: layout perl
 #
 # Setup environment variables required by perl's local::lib
@@ -1097,6 +1071,32 @@ use_node() {
     log_status "Successfully loaded NodeJS $(node --version), from prefix ($node_prefix)"
   else
     log_status "Successfully loaded NodeJS $(node --version) (via $via), from prefix ($node_prefix)"
+  fi
+}
+
+# Usage: use nodenv <node version number>
+#
+# Example:
+#
+#    use nodenv 15.2.1
+#
+# Uses nodenv, use_node and layout_node to add the chosen node version and 
+# "$PWD/node_modules/.bin" to the PATH
+#
+use_nodenv() {
+  local node_version="${1}"
+  local node_versions_dir
+  local nodenv_version
+  node_versions_dir="$(nodenv root)/versions"
+  nodenv_version="${node_versions_dir}/${node_version}"
+  if [[ -e "$nodenv_version" ]]; then
+      # Put the selected node version in the PATH
+      NODE_VERSIONS="${node_versions_dir}" NODE_VERSION_PREFIX="" use_node "${node_version}"
+      # Add $PWD/node_modules/.bin to the PATH
+      layout_node
+  else
+    log_error "nodenv: version '$node_version' not installed.  Use \`nodenv install ${node_version}\` to install it first."
+    return 1
   fi
 }
 


### PR DESCRIPTION
Similar to `layout_pyenv`, this relies on the existence of `nodenv` and its `versions` directory, e.g. `$(nodenv root)/versions`.

Unlike `layout_pyenv`, this takes only one argument and adds a single version to the `PATH`.