### PR TITLE
updated fish hook support issue

### DIFF
--- a/man/direnv.1
+++ b/man/direnv.1
@@ -89,11 +89,27 @@ eval "$(direnv hook zsh)"
 .PP
 Add the following line at the end of the \fB\fC\~/.config/fish/config.fish\fR file:
 
+
 .PP
 .RS
 
 .nf
 eval (direnv hook fish)
+
+.fi
+.RE
+
+.PP
+Fish supports 3 modes you can set with with the global environment variable \fB\fCdirenv_fish_mode\fR :
+
+
+.PP
+.RS
+
+.nf
+set -g direnv_fish_mode eval_on_arrow    # trigger direnv at prompt, and on every arrow-based directory change (default)
+set -g direnv_fish_mode eval_after_arrow # trigger direnv at prompt, and only after arrow-based directory changes before executing command
+set -g direnv_fish_mode disable_arrow    # trigger direnv at prompt only, this is similar functionality to the original behavior
 
 .fi
 .RE

--- a/man/direnv.1.md
+++ b/man/direnv.1.md
@@ -80,8 +80,17 @@ eval "$(direnv hook zsh)"
 Add the following line at the end of the `~/.config/fish/config.fish` file:
 
 ```fish
-eval (direnv hook fish)
+direnv hook fish | source
 ```
+
+Fish supports 3 modes you can set with with the global environment variable `direnv_fish_mode`:
+
+```fish
+set -g direnv_fish_mode eval_on_arrow    # trigger direnv at prompt, and on every arrow-based directory change (default)
+set -g direnv_fish_mode eval_after_arrow # trigger direnv at prompt, and only after arrow-based directory changes before executing command
+set -g direnv_fish_mode disable_arrow    # trigger direnv at prompt only, this is similar functionality to the original behavior
+```
+
 
 ### TCSH
 

--- a/shell_fish.go
+++ b/shell_fish.go
@@ -21,7 +21,7 @@ const fishHook = `
                 if test "$direnv_fish_mode" = "eval_after_arrow"
                     set -g __direnv_export_again 0
                 else
-                    # default mode (eval_on_pwd)
+                    # default mode (eval_on_arrow)
                     command direnv export fish | source
                 end
             end

--- a/shell_fish.go
+++ b/shell_fish.go
@@ -11,9 +11,34 @@ type fish struct{}
 var Fish Shell = fish{}
 
 const fishHook = `
-function __direnv_export_eval --on-event fish_postexec;
-	"{{.SelfPath}}" export fish | source;
-end
+    function __direnv_export_eval --on-event fish_prompt
+        # Run on each prompt to update the state
+        command direnv export fish | source
+
+        if test "$direnv_fish_mode" != "disable_arrow"
+            # Handle cd history arrows between now and the next prompt
+            function __direnv_cd_hook --on-variable PWD
+                if test "$direnv_fish_mode" = "eval_after_arrow"
+                    set -g __direnv_export_again 0
+                else
+                    # default mode (eval_on_pwd)
+                    command direnv export fish | source
+                end
+            end
+        end
+    end
+
+    function __direnv_export_eval_2 --on-event fish_preexec
+        if set -q __direnv_export_again
+            set -e __direnv_export_again
+            command direnv export fish | source
+            echo
+        end
+
+        # Once we're running commands, stop monitoring cd changes
+        # until we get to the prompt again
+        functions --erase __direnv_cd_hook
+    end
 `
 
 func (sh fish) Hook() (string, error) {


### PR DESCRIPTION
closes #583 

I updated the `fish hook` to handle the 3 use cases that @pjeby mentioned through an environment variable

```fish
set -g direnv_fish_mode eval_on_arrow    # trigger direnv at prompt, and on every arrow-based directory change (default)
set -g direnv_fish_mode eval_after_arrow # trigger direnv at prompt, and only after arrow-based directory changes before executing command
set -g direnv_fish_mode disable_arrow    # trigger direnv at prompt only, this is similar functionality to the original behavior
```

The `disable_arrow` option is similar to the original functionality with no support for the arrow directory change.  However, the hook is on `fish_prompt` instead of `fish_postexec` which for most use cases should provide the same functionality.

Also, update the docs to use recommended `direnv hook fish | source` format when loading the hook.
