### PR TITLE
Add `dotenv_if_exists`

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -50,7 +50,11 @@ expand\_path ../foo
 
 .SS \fB\fCdotenv [<dotenv\_path>]\fR
 .PP
-Loads a ".env" file into the current environment
+Loads a ".env" file into the current environment.
+
+.SS \fB\fCdotenv\_if\_exists [<dotenv\_path>]\fR
+.PP
+Loads a ".env" file into the current environment, but only if it exists.
 
 .SS \fB\fCuser\_rel\_path <abs\_path>\fR
 .PP

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -41,7 +41,11 @@ Example:
 
 ### `dotenv [<dotenv_path>]`
 
-Loads a ".env" file into the current environment
+Loads a ".env" file into the current environment.
+
+### `dotenv_if_exists [<dotenv_path>]`
+
+Loads a ".env" file into the current environment, but only if it exists.
 
 ### `user_rel_path <abs_path>`
 

--- a/stdlib.go
+++ b/stdlib.go
@@ -233,12 +233,30 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  elif [[ -d $path ]]; then\n" +
 	"    path=$path/.env\n" +
 	"  fi\n" +
+	"  watch_file \"$path\"\n" +
 	"  if ! [[ -f $path ]]; then\n" +
 	"    log_error \".env at $path not found\"\n" +
 	"    return 1\n" +
 	"  fi\n" +
 	"  eval \"$(\"$direnv\" dotenv bash \"$@\")\"\n" +
+	"}\n" +
+	"\n" +
+	"# Usage: dotenv_if_exists [<filename>]\n" +
+	"#\n" +
+	"# Loads a \".env\" file into the current environment, but only if it exists.\n" +
+	"#\n" +
+	"dotenv_if_exists() {\n" +
+	"  local path=${1:-}\n" +
+	"  if [[ -z $path ]]; then\n" +
+	"    path=$PWD/.env\n" +
+	"  elif [[ -d $path ]]; then\n" +
+	"    path=$path/.env\n" +
+	"  fi\n" +
 	"  watch_file \"$path\"\n" +
+	"  if ! [[ -f $path ]]; then\n" +
+	"    return\n" +
+	"  fi\n" +
+	"  eval \"$(\"$direnv\" dotenv bash \"$@\")\"\n" +
 	"}\n" +
 	"\n" +
 	"# Usage: user_rel_path <abs_path>\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -230,12 +230,30 @@ dotenv() {
   elif [[ -d $path ]]; then
     path=$path/.env
   fi
+  watch_file "$path"
   if ! [[ -f $path ]]; then
     log_error ".env at $path not found"
     return 1
   fi
   eval "$("$direnv" dotenv bash "$@")"
+}
+
+# Usage: dotenv_if_exists [<filename>]
+#
+# Loads a ".env" file into the current environment, but only if it exists.
+#
+dotenv_if_exists() {
+  local path=${1:-}
+  if [[ -z $path ]]; then
+    path=$PWD/.env
+  elif [[ -d $path ]]; then
+    path=$path/.env
+  fi
   watch_file "$path"
+  if ! [[ -f $path ]]; then
+    return
+  fi
+  eval "$("$direnv" dotenv bash "$@")"
 }
 
 # Usage: user_rel_path <abs_path>

--- a/test/stdlib.bash
+++ b/test/stdlib.bash
@@ -24,6 +24,42 @@ test_name() {
   echo "--- $*"
 }
 
+test_name dotenv
+(
+  load_stdlib
+
+  workdir=$(mktemp -d)
+  trap 'rm -rf "$workdir"' EXIT
+
+  cd "$workdir"
+
+  # Try to source a file that doesn't exist - should not succeed
+  dotenv .env.non_existing_file && return 1
+
+  # Try to source a file that exists
+  echo "export FOO=bar" > .env
+  dotenv .env
+  [[ $FOO = bar ]]
+)
+
+test_name dotenv_if_exists
+(
+  load_stdlib
+
+  workdir=$(mktemp -d)
+  trap 'rm -rf "$workdir"' EXIT
+
+  cd "$workdir"
+
+  # Try to source a file that doesn't exist - should succeed
+  dotenv_if_exists .env.non_existing_file  || return 1
+
+  # Try to source a file that exists
+  echo "export FOO=bar" > .env
+  dotenv_if_exists .env
+  [[ $FOO = bar ]]
+)
+
 test_name find_up
 (
   load_stdlib


### PR DESCRIPTION
This is a `strict_env`-friendly version of `dotenv`
for .env files which may not exist,
e.g. in the case of a boilerplate .envrc used in many places
to optionally load .env files if present.

Fixes https://github.com/direnv/direnv/issues/728.