### PR TITLE
packaging: change DESTDIR to PREFIX

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,9 +3,10 @@
 ############################################################################
 
 # Set this to change the target installation path
-DESTDIR ?= /usr/local
-BINDIR   = ${DESTDIR}/bin
-MANDIR   = ${DESTDIR}/share/man
+PREFIX   = /usr/local
+BINDIR   = ${PREFIX}/bin
+SHAREDIR = ${PREFIX}/share
+MANDIR   = ${SHAREDIR}/man
 DISTDIR ?= dist
 
 # filename of the executable
@@ -155,10 +156,12 @@ test-zsh:
 
 .PHONY: install
 install: all
-	install -d $(BINDIR)
-	install $(exe) $(BINDIR)
-	install -d $(MANDIR)/man1
-	cp -R man/*.1 $(MANDIR)/man1
+	install -d $(DESTDIR)$(BINDIR)
+	install $(exe) $(DESTDIR)$(BINDIR)
+	install -d $(DESTDIR)$(MANDIR)/man1
+	cp -R man/*.1 $(DESTDIR)$(MANDIR)/man1
+	install -d $(DESTDIR)$(SHAREDIR)/fish/vendor_conf.d
+	echo "$(BINDIR)/direnv hook fish | source" > $(DESTDIR)$(SHAREDIR)/fish/vendor_conf.d/direnv.fish
 
 .PHONY: dist
 dist:

--- a/default.nix
+++ b/default.nix
@@ -19,10 +19,7 @@ buildGoPackage rec {
   ];
 
   installPhase = ''
-    mkdir -p $out
-    make install DESTDIR=$bin
-    mkdir -p $bin/share/fish/vendor_conf.d
-    echo "eval ($bin/bin/direnv hook fish)" > $bin/share/fish/vendor_conf.d/direnv.fish
+    make install PREFIX=$bin
   '';
 
   meta = with stdenv.lib; {

--- a/docs/hook.md
+++ b/docs/hook.md
@@ -28,8 +28,16 @@ eval "$(direnv hook zsh)"
 
 Add the following line at the end of the `~/.config/fish/config.fish` file:
 
-```sh
-eval (direnv hook fish)
+```fish
+direnv hook fish | source
+```
+
+Fish supports 3 modes you can set with with the global environment variable `direnv_fish_mode`:
+
+```fish
+set -g direnv_fish_mode eval_on_arrow    # trigger direnv at prompt, and on every arrow-based directory change (default)
+set -g direnv_fish_mode eval_after_arrow # trigger direnv at prompt, and only after arrow-based directory changes before executing command
+set -g direnv_fish_mode disable_arrow    # trigger direnv at prompt only, this is similar functionality to the original behavior
 ```
 
 ## TCSH


### PR DESCRIPTION
If you are maintaining a direnv package, your packaging instructions
will have to change.

Rename DESTDIR to PREFIX. Semantically, PREFIX is used to declare where
the files will live on the file-system after installation and DESTDIR is
a temporary location used during packaging. This commit fixes that
semantic.

Distribute the fish hook with the package. These can be removed from the
packaging instructions now.