### PR TITLE
Create use_env_dir

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1167,6 +1167,26 @@ use_vim() {
   path_add DIRENV_EXTRA_VIMRC "$extra_vimrc"
 }
 
+# Usage: use_env_dir
+#
+# Load environment variables from `$(direnv_layout_dir)/envs" directory.
+# Under this directory, every file is read and set to an environment
+# variable whose name is the filename and value is the file content.
+#
+# Also watch files so to automatially reload on every file update.
+use_env_dir() {
+  local env_dir
+  env_dir="$(direnv_layout_dir)/envs"
+  if [[ -d $env_dir ]]; then
+    for f in "$env_dir"/*; do
+      if [[ -f $f ]]; then
+        watch_file "$f"
+        export "$(basename "$f")=$(cat "$f")"
+      fi
+    done
+  fi
+}
+
 # Usage: direnv_version <version_at_least>
 #
 # Checks that the direnv version is at least old as <version_at_least>.


### PR DESCRIPTION
This PR adds a stdlib function to use "env_dir".

This functionality is very similar to which is seen in [Heroku Buildpack](https://devcenter.heroku.com/articles/buildpack-api#bin-compile).

Each file under the "env_dir" represents an environment variable, whose filename to be the variable's name and content to variable's value.

So the file with the name `DB_PORT` and the content `32800` will turn to an environment variable of `DB_PORT=32800`.

----

One use case of this functionality is to launch a database server container by docker-compose and let it to pick any available port.
You can fill `DB_PORT` by creating a corresponding file as:
```console
$ mkdir -p .direnv/envs
$ docker-compose port db 5432 | cut -d ':' -f 2 > .direnv/envs/DB_PORT
```
And make your application to read the `DB_PORT`.

In this way, you can access the db without worrying about port conflict, no matter how many similar projects you are working on in parallel.