### PR TITLE
Relax README's recommendation for nix-direnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ active all day.
 Here is a list of projects you might want to look into if you are using direnv.
 
 * [starship](https://starship.rs/) - A cross-shell prompt.
-* [nix-direnv](https://github.com/nix-community/nix-direnv) - A fast, persistent use_nix implementation for direnv.
+* [Projects for Nix integration](https://github.com/direnv/direnv/wiki/Nix) - choose from one of a variety of projects offering improvements over Direnv's built-in `use_nix` implementation.
 
 ## Related projects
 


### PR DESCRIPTION
I think at this point it's not obvious that Nix-direnv is the absolute best way
to integrate Direnv with Nix.  Nix-direnv is certainly the best option for Nix
Flake support.  But for integration with Nix-shell, I think there can be valid
reasons to recommend some other approaches.

Rather than load the README with a long list of Nix integration projects (I'm
sure Direnv is used by a lot more people than Nix users), I tried to improve the
[Nix wiki page](https://github.com/direnv/direnv/wiki/Nix) to better explain the
trade-offs of different approaches so users could make a more informed decision.

So this commit just changes the pointer to Nix-direnv to point to the Nix wiki
page instead.  I just want to avoid pointing users to one project over another
when there's not one singularly best recommendation.