### PR TITLE
go: use the /v2 prefix

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -15,9 +15,6 @@ exe = direnv$(shell go env GOEXE)
 # Override the go executable
 GO = go
 
-# Change if you want to fork direnv
-PACKAGE = github.com/direnv/direnv
-
 # BASH_PATH can also be passed to hard-code the path to bash at build time
 
 SHELL = bash

--- a/cmd_fetchurl.go
+++ b/cmd_fetchurl.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/direnv/direnv/sri"
+	"github.com/direnv/direnv/v2/sri"
 	"github.com/mattn/go-isatty"
 )
 

--- a/cmd_show_dump.go
+++ b/cmd_show_dump.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/direnv/direnv/gzenv"
+	"github.com/direnv/direnv/v2/gzenv"
 )
 
 // CmdShowDump is `direnv show_dump`

--- a/config.go
+++ b/config.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	toml "github.com/BurntSushi/toml"
-	"github.com/direnv/direnv/xdg"
+	"github.com/direnv/direnv/v2/xdg"
 )
 
 // Config represents the direnv configuration and state.

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@ buildGoModule rec {
   version = lib.fileContents ./version.txt;
   subPackages = [ "." ];
 
-  vendorSha256 = "0yhppxrippxayqqs3m7imi0zr7y9zln1krnc7drsi3p2a66xwlwq";
+  vendorSha256 = "1kmgl3wkbyirqkf7rwlcss8ml7incxclsb36nskwx1w6b1ilphrz";
 
   src = lib.cleanSource ./.;
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 Setup a go environment https://golang.org/doc/install
 
-> go >= 1.11 is required
+> go >= 1.15 is required
 
 Clone the project:
 

--- a/env.go
+++ b/env.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/direnv/direnv/gzenv"
+	"github.com/direnv/direnv/v2/gzenv"
 )
 
 // Env is a map representation of environment variables.

--- a/env_diff.go
+++ b/env_diff.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	"github.com/direnv/direnv/gzenv"
+	"github.com/direnv/direnv/v2/gzenv"
 )
 
 // IgnoredKeys is list of keys we don't want to deal with

--- a/file_times.go
+++ b/file_times.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/direnv/direnv/gzenv"
+	"github.com/direnv/direnv/v2/gzenv"
 )
 
 // FileTime represents a single recorded file status

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/direnv/direnv
+module github.com/direnv/direnv/v2
 
-go 1.12
+go 1.15
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/shell_gzenv.go
+++ b/shell_gzenv.go
@@ -3,7 +3,7 @@ package main
 import (
 	"errors"
 
-	"github.com/direnv/direnv/gzenv"
+	"github.com/direnv/direnv/v2/gzenv"
 )
 
 type gzenvShell int


### PR DESCRIPTION
Fix the usage of Go modules so that `go get` actually installs the
latest version.

Bump the minimal Go version requirement to 1.15.

Fixes #629 and #762