### PR TITLE
test: Fix errors for elvish test

### DIFF
--- a/cmd_export.go
+++ b/cmd_export.go
@@ -64,7 +64,7 @@ func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 	var previousEnv, newEnv Env
 
 	if previousEnv, err = config.Revert(currentEnv); err != nil {
-		err = fmt.Errorf("Revert() failed: %q", err)
+		err = fmt.Errorf("Revert() failed: %w", err)
 		logDebug("err: %v", err)
 		return
 	}

--- a/cmd_watch_dir.go
+++ b/cmd_watch_dir.go
@@ -49,7 +49,7 @@ func watchDirCommand(env Env, args []string) (err error) {
 		return watches.NewTime(path, info.ModTime().Unix(), true)
 	})
 	if err != nil {
-		return fmt.Errorf("failed to recursively watch dir '%s': %v", dir, err)
+		return fmt.Errorf("failed to recursively watch dir '%s': %w", dir, err)
 	}
 
 	e := make(ShellExport)

--- a/cmd_watch_list.go
+++ b/cmd_watch_list.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -55,7 +56,7 @@ func watchListCommand(env Env, args []string) (err error) {
 			}
 			mtime, err := strconv.Atoi(elems[0])
 			if err != nil {
-				return fmt.Errorf("line %d: %s", i, err)
+				return fmt.Errorf("line %d: %w", i, err)
 			}
 			path := elems[1][:len(elems[1])-1]
 
@@ -64,10 +65,10 @@ func watchListCommand(env Env, args []string) (err error) {
 			if err != nil {
 				return err
 			}
-		} else if err == io.EOF {
+		} else if errors.Is(err, io.EOF) {
 			break
 		} else {
-			return fmt.Errorf("line %d: %s", i, err)
+			return fmt.Errorf("line %d: %w", i, err)
 		}
 		i++
 	}

--- a/config.go
+++ b/config.go
@@ -75,7 +75,7 @@ func LoadConfig(env Env) (config *Config, err error) {
 
 	var exePath string
 	if exePath, err = os.Executable(); err != nil {
-		err = fmt.Errorf("LoadConfig() os.Executable() failed: %q", err)
+		err = fmt.Errorf("LoadConfig() os.Executable() failed: %w", err)
 		return
 	}
 	// Fix for mingsys
@@ -83,7 +83,7 @@ func LoadConfig(env Env) (config *Config, err error) {
 	config.SelfPath = exePath
 
 	if config.WorkDir, err = os.Getwd(); err != nil {
-		err = fmt.Errorf("LoadConfig() Getwd failed: %q", err)
+		err = fmt.Errorf("LoadConfig() Getwd failed: %w", err)
 		return
 	}
 
@@ -114,7 +114,7 @@ func LoadConfig(env Env) (config *Config, err error) {
 			Global:     &global,
 		}
 		if _, err = toml.DecodeFile(config.TomlPath, &tomlConf); err != nil {
-			err = fmt.Errorf("LoadConfig() failed to parse %s: %q", config.TomlPath, err)
+			err = fmt.Errorf("LoadConfig() failed to parse %s: %w", config.TomlPath, err)
 			return
 		}
 
@@ -149,7 +149,7 @@ func LoadConfig(env Env) (config *Config, err error) {
 		} else if bashPath != "" {
 			config.BashPath = bashPath
 		} else if config.BashPath, err = exec.LookPath("bash"); err != nil {
-			err = fmt.Errorf("can't find bash: %q", err)
+			err = fmt.Errorf("can't find bash: %w", err)
 			return
 		}
 	}

--- a/gzenv/gzenv.go
+++ b/gzenv/gzenv.go
@@ -17,7 +17,7 @@ func Marshal(obj interface{}) string {
 	jsonData, err := json.Marshal(obj)
 
 	if err != nil {
-		panic(fmt.Errorf("marshal(): %v", err))
+		panic(fmt.Errorf("marshal(): %w", err))
 	}
 
 	zlibData := bytes.NewBuffer([]byte{})
@@ -37,13 +37,13 @@ func Unmarshal(gzenv string, obj interface{}) error {
 
 	data, err := base64.URLEncoding.DecodeString(gzenv)
 	if err != nil {
-		return fmt.Errorf("unmarshal() base64 decoding: %v", err)
+		return fmt.Errorf("unmarshal() base64 decoding: %w", err)
 	}
 
 	zlibReader := bytes.NewReader(data)
 	w, err := zlib.NewReader(zlibReader)
 	if err != nil {
-		return fmt.Errorf("unmarshal() zlib opening: %v", err)
+		return fmt.Errorf("unmarshal() zlib opening: %w", err)
 	}
 
 	envData := bytes.NewBuffer([]byte{})
@@ -51,13 +51,13 @@ func Unmarshal(gzenv string, obj interface{}) error {
 	// #nosec
 	_, err = io.Copy(envData, w)
 	if err != nil {
-		return fmt.Errorf("unmarshal() zlib decoding: %v", err)
+		return fmt.Errorf("unmarshal() zlib decoding: %w", err)
 	}
 	w.Close()
 
 	err = json.Unmarshal(envData.Bytes(), &obj)
 	if err != nil {
-		return fmt.Errorf("unmarshal() json parsing: %v", err)
+		return fmt.Errorf("unmarshal() json parsing: %w", err)
 	}
 
 	return nil

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,15 @@
 {
     "nixpkgs": {
-        "branch": "nixos-20.09",
+        "branch": "nixos-unstable",
+        "builtin": true,
         "description": "Nixpkgs/NixOS branches that track the Nixpkgs/NixOS channels",
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0c81b9a4f170f734bd7e587a39e56470c59733e7",
-        "sha256": "1fl5ks6p78bamqanbk9xpy83jzzcdw2mdabrp59n33xv7jix1jzx",
+        "rev": "916ee862e87ac5ee2439f2fb7856386b4dc906ae",
+        "sha256": "165byy4hgg44w4ks1l289yx98bifqwyk6amil9rq7z7978d5lsj9",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/0c81b9a4f170f734bd7e587a39e56470c59733e7.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/916ee862e87ac5ee2439f2fb7856386b4dc906ae.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/script/str2go.go
+++ b/script/str2go.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -50,7 +51,7 @@ func main() {
 	for {
 		r, _, err := in.ReadRune()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			panic(err)

--- a/test/direnv-test.elv
+++ b/test/direnv-test.elv
@@ -1,9 +1,11 @@
 #!/usr/bin/env elvish
 
-E:TEST_DIR = (path-dir (src)[path])
+use path
+
+E:TEST_DIR = (path:dir (src)[name])
 set-env XDG_CONFIG_HOME $E:TEST_DIR/config
 set-env XDG_DATA_HOME $E:TEST_DIR/data
-E:PATH = (path-dir $E:TEST_DIR):$E:PATH
+E:PATH = (path:dir $E:TEST_DIR):$E:PATH
 
 cd $E:TEST_DIR
 
@@ -80,7 +82,7 @@ test-scenario base {
 	direnv-eval
 	test-eq $E:HELLO "world"
 
-	E:WATCHES=$E:DIRENV_WATCHES
+	set E:WATCHES = $E:DIRENV_WATCHES
 
 	echo "Reloading (should be no-op)"
 	direnv-eval


### PR DESCRIPTION
In recent versions of elvish the builtin path-dir has been moved to a
module. Update the test script to use the module to avoid a warning
about deprecated usage. The move of "path" to the module also seems to
have updated the key "path" to "name" - reflect this in the test
script.

Similarly, temporary assignment now requires using the "set"
keyword. Fix this while at it.