### PR TITLE
pipenv --python $PYTHON_VERSION

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -867,9 +867,13 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"    exit 2\n" +
 	"  fi\n" +
 	"\n" +
+	"  PYTHON_VERSION=$(python --version | cut -d\" \" -f2)\n" +
 	"  VIRTUAL_ENV=$(pipenv --venv 2>/dev/null ; true)\n" +
 	"\n" +
 	"  if [[ -z $VIRTUAL_ENV || ! -d $VIRTUAL_ENV ]]; then\n" +
+	"    if [[ $PYTHON_VERSION ]]; then\n" +
+	"      pipenv --python $PYTHON_VERSION\n" +
+	"    fi\n" +
 	"    pipenv install --dev\n" +
 	"    VIRTUAL_ENV=$(pipenv --venv)\n" +
 	"  fi\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -864,9 +864,13 @@ layout_pipenv() {
     exit 2
   fi
 
+  PYTHON_VERSION=$(python --version | cut -d" " -f2)
   VIRTUAL_ENV=$(pipenv --venv 2>/dev/null ; true)
 
   if [[ -z $VIRTUAL_ENV || ! -d $VIRTUAL_ENV ]]; then
+    if [[ $PYTHON_VERSION ]]; then
+      pipenv --python $PYTHON_VERSION
+    fi
     pipenv install --dev
     VIRTUAL_ENV=$(pipenv --venv)
   fi


### PR DESCRIPTION
`⠙ Creating virtual environment...FileNotFoundError: [Errno 2] No such file or directory: '/shims/python'`

Above could happen, if it is to use python from pyenv, instead of the one from system.