### PR TITLE
Change DESTDIR to PREFIX in development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -23,4 +23,4 @@ To install to /usr/local:
 
 Or to a different location like `~/.local`:
 
-    $ make install DESTDIR=~/.local
+    $ make install PREFIX=~/.local


### PR DESCRIPTION
The `GNUmakefile` uses the `PREFIX=/usr/local` for the install, so it should be replaced and not the `DESTDIR`.