### PR TITLE
Go 1.16 and Apple Silicon support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: 1.15.5
+        go-version: 1.16
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13.6
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: 1.13.6
+          go-version: 1.16
       - name: Checkout code
         uses: actions/checkout@v2.3.4
       - name: Get release notes

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -164,6 +164,7 @@ dist:
 	@command -v gox >/dev/null || (echo "Could not generate dist because gox is missing. Run: go get -u github.com/mitchellh/gox"; false)
 	CGO_ENABLED=0 gox -output "$(DISTDIR)/direnv.{{.OS}}-{{.Arch}}" \
 		-osarch darwin/amd64 \
+		-osarch darwin/arm64 \
 		-osarch freebsd/386 \
 		-osarch freebsd/amd64 \
 		-osarch freebsd/arm \

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 Setup a go environment https://golang.org/doc/install
 
-> go >= 1.15 is required
+> go >= 1.16 is required
 
 Clone the project:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/direnv/direnv/v2
 
-go 1.15
+go 1.16
 
 require (
 	github.com/BurntSushi/toml v0.3.1


### PR DESCRIPTION
- Bumps Go up to 1.16
- Adds `darwin/arm64` to the list of architectures to build against

Resolves #738 

