### PR TITLE
Remove noisy warning about PS1 again

### DIFF
--- a/rc.go
+++ b/rc.go
@@ -193,9 +193,6 @@ func (rc *RC) Load(previousEnv Env) (newEnv Env, err error) {
 		if err == nil {
 			newEnv = newEnv2
 		}
-		if newEnv2["PS1"] != "" {
-			logError("PS1 cannot be exported. For more information see https://github.com/direnv/direnv/wiki/PS1")
-		}
 	}
 
 	return


### PR DESCRIPTION
As there is no movement on a more specific PS1 warning (as suggested in https://github.com/direnv/direnv/issues/618), and there is light support for removing it completely via "thumbs up", putting up this PR for discussion.

As discussed there, it seems to me this warning slipped in due to probably an abundance of PS1 complaints at that time, which should be fixed now that the issue is amply documented. There are likely many other things that "don't work" and could be warned about, so at least from my perspective, there's a wavy line between warning "just in case", vs. the noise this produces, at least in every Python virtualenv-based use case (which can be silenced with `unset PS1`, but...).