### PR TITLE
Fixed extra quotes for lower alpha characters

### DIFF
--- a/shell_bash.go
+++ b/shell_bash.go
@@ -71,12 +71,13 @@ const (
 	PLUS          = 43
 	NINE          = 57
 	QUESTION      = 63
-	LOWERCASE_Z   = 90
+	UPPERCASE_Z   = 90
 	OPEN_BRACKET  = 91
 	BACKSLASH     = 92
 	UNDERSCORE    = 95
 	CLOSE_BRACKET = 93
 	BACKTICK      = 96
+	LOWERCASE_Z   = 122
 	TILDA         = 126
 	DEL           = 127
 )
@@ -146,7 +147,7 @@ func BashEscape(str string) string {
 			literal(char)
 		case char <= QUESTION:
 			quoted(char)
-		case char <= LOWERCASE_Z:
+		case char <= UPPERCASE_Z:
 			literal(char)
 		case char == OPEN_BRACKET:
 			quoted(char)

--- a/shell_tcsh.go
+++ b/shell_tcsh.go
@@ -101,13 +101,15 @@ func (sh tcsh) escape(str string) string {
 			literal(char)
 		case char <= QUESTION:
 			quoted(char)
-		case char <= LOWERCASE_Z:
+		case char <= UPPERCASE_Z:
 			literal(char)
 		case char == OPEN_BRACKET:
 			quoted(char)
 		case char == BACKSLASH:
 			backslash(char)
 		case char == UNDERSCORE:
+			literal(char)
+		case char <= LOWERCASE_Z:
 			literal(char)
 		case char <= CLOSE_BRACKET:
 			quoted(char)


### PR DESCRIPTION
PR 788 (https://github.com/direnv/direnv/pull/778) to fix  #769 introduced extra quotes around lower case characters.  This PR should fix that issue.  Also, fixed a const misnomer 'LOWERCASE_Z', ascii 90 is uppercase `Z`. 