### PR TITLE
Add -r flag for matching Git branches with a regexp

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -1214,7 +1214,7 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"    return 1\n" +
 	"  elif [ -z \"$1\" ]; then\n" +
 	"    return 0\n" +
-	"  elif [ \"$1\" = \"-r\" ] && [ -z \"$2\" ]; then\n" +
+	"  elif [[ \"$1\" = \"-r\"  &&  -z \"$2\" ]]; then\n" +
 	"    log_error \"missing regexp pattern after \\`-r\\` flag\"\n" +
 	"    return 1\n" +
 	"  fi\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -1221,7 +1221,11 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  watch_file \"$git_dir/HEAD\"\n" +
 	"  local git_branch\n" +
 	"  git_branch=$(git branch --show-current)\n" +
-	"  [ \"$1\" = \"$git_branch\" ] || [ \"$1\" = '-r' ] && [[ \"$git_branch\" =~ $2 ]]\n" +
+	"  if [ \"$1\" = '-r' ]; then\n" +
+	"    [[ \"$git_branch\" =~ $2 ]]\n" +
+	"  else\n" +
+	"    [ \"$1\" = \"$git_branch\" ]\n" +
+	"  fi\n" +
 	"}\n" +
 	"\n" +
 	"# Usage: __main__ <cmd> [...<args>]\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -1215,7 +1215,7 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  elif [ -z \"$1\" ]; then\n" +
 	"    return 0\n" +
 	"  elif [ \"$1\" = \"-r\" ] && [ -z \"$2\" ]; then\n" +
-	"    log_error \"missing regexp pattern after `-r` flag\"\n" +
+	"    log_error \"missing regexp pattern after \\`-r\\` flag\"\n" +
 	"    return 1\n" +
 	"  fi\n" +
 	"  watch_file \"$git_dir/HEAD\"\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -1177,23 +1177,32 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"  \"$direnv\" version \"$@\"\n" +
 	"}\n" +
 	"\n" +
-	"# Usage: on_git_branch [<branch_name>]\n" +
+	"# Usage: on_git_branch [<branch_name>] OR on_git_branch -r [<regexp>]\n" +
 	"#\n" +
 	"# Returns 0 if within a git repository with given `branch_name`. If no branch\n" +
 	"# name is provided, then returns 0 when within _any_ branch. Requires the git\n" +
 	"# command to be installed. Returns 1 otherwise.\n" +
 	"#\n" +
-	"# When a branch is specified, then `.git/HEAD` is watched so that\n" +
+	"# When the `-r` flag is specified, then the second argument is interpreted as a\n" +
+	"# regexp pattern for matching a branch name.\n" +
+	"#\n" +
+	"# Regardless, when a branch is specified, then `.git/HEAD` is watched so that\n" +
 	"# entering/exiting a branch triggers a reload.\n" +
 	"#\n" +
 	"# Example (.envrc):\n" +
+	"#\n" +
+	"#    if on_git_branch; then\n" +
+	"#      echo \"Thanks for contributing to a GitHub project!\"\n" +
+	"#    fi\n" +
 	"#\n" +
 	"#    if on_git_branch child_changes; then\n" +
 	"#      export MERGE_BASE_BRANCH=parent_changes\n" +
 	"#    fi\n" +
 	"#\n" +
-	"#    if on_git_branch; then\n" +
-	"#      echo \"Thanks for contributing to a GitHub project!\"\n" +
+	"#    if on_git_branch -r '.*py2'; then\n" +
+	"#      layout python2\n" +
+	"#    else\n" +
+	"#      layout python\n" +
 	"#    fi\n" +
 	"on_git_branch() {\n" +
 	"  local git_dir\n" +
@@ -1205,9 +1214,14 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"    return 1\n" +
 	"  elif [ -z \"$1\" ]; then\n" +
 	"    return 0\n" +
+	"  elif [ \"$1\" = \"-r\" ] && [ -z \"$2\" ]; then\n" +
+	"    log_error \"missing regexp pattern after `-r` flag\"\n" +
+	"    return 1\n" +
 	"  fi\n" +
 	"  watch_file \"$git_dir/HEAD\"\n" +
-	"  [ \"$(git branch --show-current)\" = \"$1\" ]\n" +
+	"  local git_branch\n" +
+	"  git_branch=$(git branch --show-current)\n" +
+	"  [ \"$1\" = \"$git_branch\" ] || [ \"$1\" = '-r' ] && [[ \"$git_branch\" =~ $2 ]]\n" +
 	"}\n" +
 	"\n" +
 	"# Usage: __main__ <cmd> [...<args>]\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1212,7 +1212,7 @@ on_git_branch() {
   elif [ -z "$1" ]; then
     return 0
   elif [ "$1" = "-r" ] && [ -z "$2" ]; then
-    log_error "missing regexp pattern after `-r` flag"
+    log_error "missing regexp pattern after \`-r\` flag"
     return 1
   fi
   watch_file "$git_dir/HEAD"

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1218,7 +1218,11 @@ on_git_branch() {
   watch_file "$git_dir/HEAD"
   local git_branch
   git_branch=$(git branch --show-current)
-  [ "$1" = "$git_branch" ] || [ "$1" = '-r' ] && [[ "$git_branch" =~ $2 ]]
+  if [ "$1" = '-r' ]; then
+    [[ "$git_branch" =~ $2 ]]
+  else
+    [ "$1" = "$git_branch" ]
+  fi
 }
 
 # Usage: __main__ <cmd> [...<args>]

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1174,23 +1174,32 @@ direnv_version() {
   "$direnv" version "$@"
 }
 
-# Usage: on_git_branch [<branch_name>]
+# Usage: on_git_branch [<branch_name>] OR on_git_branch -r [<regexp>]
 #
 # Returns 0 if within a git repository with given `branch_name`. If no branch
 # name is provided, then returns 0 when within _any_ branch. Requires the git
 # command to be installed. Returns 1 otherwise.
 #
-# When a branch is specified, then `.git/HEAD` is watched so that
+# When the `-r` flag is specified, then the second argument is interpreted as a
+# regexp pattern for matching a branch name.
+#
+# Regardless, when a branch is specified, then `.git/HEAD` is watched so that
 # entering/exiting a branch triggers a reload.
 #
 # Example (.envrc):
+#
+#    if on_git_branch; then
+#      echo "Thanks for contributing to a GitHub project!"
+#    fi
 #
 #    if on_git_branch child_changes; then
 #      export MERGE_BASE_BRANCH=parent_changes
 #    fi
 #
-#    if on_git_branch; then
-#      echo "Thanks for contributing to a GitHub project!"
+#    if on_git_branch -r '.*py2'; then
+#      layout python2
+#    else
+#      layout python
 #    fi
 on_git_branch() {
   local git_dir
@@ -1202,9 +1211,14 @@ on_git_branch() {
     return 1
   elif [ -z "$1" ]; then
     return 0
+  elif [ "$1" = "-r" ] && [ -z "$2" ]; then
+    log_error "missing regexp pattern after `-r` flag"
+    return 1
   fi
   watch_file "$git_dir/HEAD"
-  [ "$(git branch --show-current)" = "$1" ]
+  local git_branch
+  git_branch=$(git branch --show-current)
+  [ "$1" = "$git_branch" ] || [ "$1" = '-r' ] && [[ "$git_branch" =~ $2 ]]
 }
 
 # Usage: __main__ <cmd> [...<args>]

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1211,7 +1211,7 @@ on_git_branch() {
     return 1
   elif [ -z "$1" ]; then
     return 0
-  elif [ "$1" = "-r" ] && [ -z "$2" ]; then
+  elif [[ "$1" = "-r"  &&  -z "$2" ]]; then
     log_error "missing regexp pattern after \`-r\` flag"
     return 1
   fi


### PR DESCRIPTION
I've found it to be very helpful to be able to match a regexp rather than an exact GitHub branch. In my use case, I do this to choose between a Python 2 layout vs Python 3, for example (included in documentation):

```bash
if on_git_branch -r '.*py2'; then
  layout python2
else
  layout python
fi
```