### PR TITLE
Updated conditional for zsh hook to be more forgiving

### DIFF
--- a/shell_zsh.go
+++ b/shell_zsh.go
@@ -13,11 +13,11 @@ _direnv_hook() {
   trap - SIGINT;
 }
 typeset -ag precmd_functions;
-if [[ -z ${precmd_functions[(r)_direnv_hook]} ]]; then
+if [[ -z "${precmd_functions[(r)_direnv_hook]+1}" ]]; then
   precmd_functions=( _direnv_hook ${precmd_functions[@]} )
 fi
 typeset -ag chpwd_functions;
-if [[ -z ${chpwd_functions[(r)_direnv_hook]} ]]; then
+if [[ -z "${chpwd_functions[(r)_direnv_hook]+1}" ]]; then
   chpwd_functions=( _direnv_hook ${chpwd_functions[@]} )
 fi
 `


### PR DESCRIPTION
closes #803 

The issue is when something like `set -e` or `set -euo pipefail` is set, it causes the conditional check to fail and then the entire script for the hook exits.

This updates the conditional so that it doesn't error out in this scenario. It's adapted from the POSIX-compliant test here:
https://stackoverflow.com/questions/42655304/how-do-i-check-if-a-variable-is-set-in-zsh