### PR TITLE
Allow optional leading v in .node-version file

### DIFF
--- a/stdlib.go
+++ b/stdlib.go
@@ -1073,6 +1073,8 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"\n" +
 	"  if [[ -z $version && -f .node-version ]]; then\n" +
 	"    version=$(<.node-version)\n" +
+    "    # Remove optional leading v\n" +
+    "    version=${version#v}\n" +
 	"    via=\".node-version\"\n" +
 	"  fi\n" +
 	"\n" +

--- a/stdlib.go
+++ b/stdlib.go
@@ -1073,8 +1073,8 @@ const StdLib = "#!/usr/bin/env bash\n" +
 	"\n" +
 	"  if [[ -z $version && -f .node-version ]]; then\n" +
 	"    version=$(<.node-version)\n" +
-    "    # Remove optional leading v\n" +
-    "    version=${version#v}\n" +
+	"    # Remove optional leading v\n" +
+	"    version=${version#v}\n" +
 	"    via=\".node-version\"\n" +
 	"  fi\n" +
 	"\n" +

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1070,6 +1070,8 @@ use_node() {
 
   if [[ -z $version && -f .node-version ]]; then
     version=$(<.node-version)
+    # Remove optional leading v
+    version=${version#v}
     via=".node-version"
   fi
 


### PR DESCRIPTION
This is a small suggested feature for convenience of users and greater compatibility with other products using `.node-version`. Feel free to reject!

Related use cases:

1) Node includes a leading `v` when displaying its version. This might be written into a version control file:

```
$ node --version
v10.15.3
$ node --version > .node-version
```

2) Most of the other node version managers that support `.node-version` file allow a leading `v` on the version.

- https://github.com/shadowspawn/node-version-usage

3) `nvm` supports leading `v` on version when used directly, and the `v` is included in the example here: https://github.com/direnv/direnv/wiki/Node

> Now in any directory, put a Node version number like v14.15.4 in .nvmrc and put use nvm in .envrc.

-----

Example file:

```
% cat .node-version 
v10.12.0
```

Before fix:

```
% direnv reload     
direnv: loading ~/node-version/eol-lin/.envrc                                                                                 
direnv: using node
direnv: Unable to load NodeJS binary (node) for version (v10.12.0) in (/usr/local/n/versions/node)!
```

After fix: 
```
% direnv reload
direnv: loading ~/node-version/eol-lin/.envrc                                                                                 
direnv: using node
direnv: Successfully loaded NodeJS v10.12.0 (via .node-version), from prefix (/usr/local/n/versions/node/10.12.0)
direnv: export +CPATH +LD_LIBRARY_PATH +LIBRARY_PATH +MANPATH +PKG_CONFIG_PATH ~PATH
```

-----

Paranoia: This could break users who are specifying a `v` which is part of the path to the node on disk with their setup. The work-around for the user would be to add the `v` into `NODE_VERSION_PREFIX`.
