### PR TITLE
update installer for Apple Silicon

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ set -euo pipefail
     i686 | i386)
       machine=386
       ;;
-    aarch64)
+    aarch64 | arm64)
       machine=arm64
       ;;
     *)


### PR DESCRIPTION
I can't run `curl -sfL https://direnv.net/install.sh | bash` on macOS with Apple Silicon

```
[installer] Machine arm64 not supported by the installer.\n Go to https://direnv for alternate installation methods.
[installer] the script failed with error 1.\n \n To report installation errors, submit an issue to\n     https://github.com/direnv/direnv/issues/new/choose
```

But, direnv supported Apple Silicon https://github.com/direnv/direnv/pull/779
I was able to install it with this modified script.