### PR TITLE
stdlib: use_flake handle no layout dir

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1154,6 +1154,7 @@ use_nix() {
 use_flake() {
   watch_file flake.nix
   watch_file flake.lock
+  mkdir -p "$(direnv_layout_dir)"
   eval "$(nix print-dev-env --profile "$(direnv_layout_dir)/flake-profile" "$@")"
 }
 


### PR DESCRIPTION
Nix doesn't automatically create the folder if it doesn't exist, so we
have to do it ourselves.

Fixes #860