### PR TITLE
source_env: show full path

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -346,7 +346,7 @@ source_env() {
   pushd "$(pwd 2>/dev/null)" >/dev/null || return 1
   pushd "$rcpath_dir" >/dev/null || return 1
   if [[ -f ./$rcpath_base ]]; then
-    log_status "loading $rcfile"
+    log_status "loading $(user_rel_path "$(expand_path "$rcpath")")"
     # shellcheck disable=SC1090
     . "./$rcpath_base"
   else

--- a/test/stdlib.bash
+++ b/test/stdlib.bash
@@ -190,6 +190,11 @@ test_name source_env_if_exists
   echo "export FOO=bar" > existing_file
   source_env_if_exists existing_file
   [[ $FOO = bar ]]
+
+  # Expect correct path being logged
+  export HOME=$workdir
+  output="$(source_env_if_exists existing_file 2>&1 > /dev/null)"
+  [[ "${output#*'loading ~/existing_file'}" != "$output" ]]
 )
 
 test_name env_vars_required


### PR DESCRIPTION
Paths passed to `source_env(_if_exists)` are logged as-is, e.g. `.envrc.local`.
This PR ensures the full path is logged, like with `source_up`.
```bash
$ cat foo/.envrc
source_up
source_env .envrc.local

# CURRENT
$ direnv exec foo true
direnv: loading ~/src/direnv/foo/.envrc
direnv: loading ~/src/direnv/.envrc
direnv: loading .envrc.local

# PR
$ direnv exec foo true
direnv: loading ~/src/direnv/foo/.envrc
direnv: loading ~/src/direnv/.envrc
direnv: loading ~/src/direnv/foo/.envrc.local
```