### PR TITLE
gosh-related refactors

### DIFF
--- a/internal/cmd/cmd_stdlib.go
+++ b/internal/cmd/cmd_stdlib.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 )
 
 // CmdStdlib is `direnv stdlib`
@@ -10,7 +9,7 @@ var CmdStdlib = &Cmd{
 	Name: "stdlib",
 	Desc: "Displays the stdlib available in the .envrc execution context",
 	Action: actionWithConfig(func(env Env, args []string, config *Config) error {
-		fmt.Println(strings.Replace(stdlib, "$(command -v direnv)", config.SelfPath, 1))
+		fmt.Println(getStdlib(config))
 		return nil
 	}),
 }

--- a/internal/cmd/rc.go
+++ b/internal/cmd/rc.go
@@ -194,7 +194,7 @@ func (rc *RC) Load(previousEnv Env) (newEnv Env, err error) {
 
 	// G204: Subprocess launched with function call as argument or cmd arguments
 	// #nosec
-	cmd := exec.CommandContext(ctx, config.BashPath, "--noprofile", "--norc", "-c", arg)
+	cmd := exec.CommandContext(ctx, config.BashPath, "-c", arg)
 	cmd.Dir = wd
 	cmd.Env = newEnv.ToGoEnv()
 	cmd.Stdin = stdin

--- a/internal/cmd/rc.go
+++ b/internal/cmd/rc.go
@@ -151,6 +151,15 @@ func (rc *RC) Load(previousEnv Env) (newEnv Env, err error) {
 		return
 	}
 
+	// Allow RC loads to be canceled with SIGINT
+	ctx, cancel := context.WithCancel(context.Background())
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		<-c
+		cancel()
+	}()
+
 	// check what type of RC we're processing
 	// use different exec method for each
 	fn := "source_env"
@@ -170,15 +179,6 @@ func (rc *RC) Load(previousEnv Env) (newEnv Env, err error) {
 		fn,
 		rc.Path(),
 	)
-
-	// Allow RC loads to be canceled with SIGINT
-	ctx, cancel := context.WithCancel(context.Background())
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	go func() {
-		<-c
-		cancel()
-	}()
 
 	// G204: Subprocess launched with function call as argument or cmd arguments
 	// #nosec

--- a/internal/cmd/stdlib.go
+++ b/internal/cmd/stdlib.go
@@ -1,0 +1,8 @@
+package cmd
+
+import "strings"
+
+// getStdlib returns the stdlib.sh, with references to direnv replaced.
+func getStdlib(config *Config) string {
+	return strings.Replace(stdlib, "$(command -v direnv)", config.SelfPath, 1)
+}


### PR DESCRIPTION
Reduce the amount of commits to land with the gosh branch.

- stdlib: factor out stdlib preparation
- rc: install interrupt handler earlier
- rc: prepare stdin earlier
- rc: stop using --noprofile --norc

