### PR TITLE
Allow skipping `.env` autoload

### DIFF
--- a/internal/cmd/cmd_exec.go
+++ b/internal/cmd/cmd_exec.go
@@ -52,7 +52,7 @@ func cmdExecAction(env Env, args []string, config *Config) (err error) {
 	previousEnv.CleanContext()
 
 	// Load the rc
-	if toLoad := findEnvUp(rcPath); toLoad != "" {
+	if toLoad := findEnvUp(rcPath, config.SkipDotenv); toLoad != "" {
 		if newEnv, err = config.EnvFromRC(toLoad, previousEnv); err != nil {
 			return
 		}

--- a/internal/cmd/cmd_export.go
+++ b/internal/cmd/cmd_export.go
@@ -34,7 +34,7 @@ func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 
 	logDebug("loading RCs")
 	loadedRC := config.LoadedRC()
-	toLoad := findEnvUp(config.WorkDir)
+	toLoad := findEnvUp(config.WorkDir, config.SkipDotenv)
 
 	if loadedRC == nil && toLoad == "" {
 		return

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	TomlPath        string
 	DisableStdin    bool
 	StrictEnv       bool
+	SkipDotenv      bool
 	WarnTimeout     time.Duration
 	WhitelistPrefix []string
 	WhitelistExact  map[string]bool
@@ -50,6 +51,7 @@ type tomlGlobal struct {
 	BashPath     string       `toml:"bash_path"`
 	DisableStdin bool         `toml:"disable_stdin"`
 	StrictEnv    bool         `toml:"strict_env"`
+	SkipDotenv   bool         `toml:"skip_dotenv"`
 	WarnTimeout  tomlDuration `toml:"warn_timeout"`
 }
 
@@ -128,6 +130,7 @@ func LoadConfig(env Env) (config *Config, err error) {
 		config.BashPath = tomlConf.BashPath
 		config.DisableStdin = tomlConf.DisableStdin
 		config.StrictEnv = tomlConf.StrictEnv
+		config.SkipDotenv = tomlConf.SkipDotenv
 		config.WarnTimeout = tomlConf.WarnTimeout.Duration
 	}
 

--- a/internal/cmd/rc.go
+++ b/internal/cmd/rc.go
@@ -24,7 +24,7 @@ type RC struct {
 
 // FindRC looks for ".envrc" and ".env" files up in the file hierarchy.
 func FindRC(wd string, config *Config) (*RC, error) {
-	rcPath := findEnvUp(wd)
+	rcPath := findEnvUp(wd, config.SkipDotenv)
 	if rcPath == "" {
 		return nil, nil
 	}
@@ -287,7 +287,11 @@ func allow(path string, allowPath string) (err error) {
 	return ioutil.WriteFile(allowPath, []byte(path+"\n"), 0644)
 }
 
-func findEnvUp(searchDir string) (path string) {
+func findEnvUp(searchDir string, skipDotenv bool) (path string) {
+	if skipDotenv {
+		return findUp(searchDir, ".envrc")
+	}
+
 	return findUp(searchDir, ".envrc", ".env")
 }
 

--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -52,6 +52,10 @@ This allows one to hard-code the position of bash. It maybe be useful to set thi
 .PP
 If set to \fB\fCtrue\fR, stdin is disabled (redirected to /dev/null) during the \fB\fC\&.envrc\fR evaluation.
 
+.SS \fB\fCskip_dotenv\fR
+.PP
+Don't look for \fB\fC\&.env\fR files, only \fB\fC\&.envrc\fR files.
+
 .SS \fB\fCstrict_env\fR
 .PP
 If set to true, the \fB\fC\&.envrc\fR will be loaded with \fB\fCset -euo pipefail\fR\&. This

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -42,6 +42,10 @@ This allows one to hard-code the position of bash. It maybe be useful to set thi
 
 If set to `true`, stdin is disabled (redirected to /dev/null) during the `.envrc` evaluation.
 
+### `skip_dotenv`
+
+Don't look for `.env` files, only `.envrc` files.
+
 ### `strict_env`
 
 If set to true, the `.envrc` will be loaded with `set -euo pipefail`. This

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -47,6 +47,7 @@ test_start() {
 }
 
 test_stop() {
+  rm -f "${XDG_CONFIG_HOME}/direnv/direnv.toml"
   cd /
   direnv_eval
 }
@@ -236,6 +237,13 @@ test_stop
 test_start "load-env"
   direnv_eval
   test_eq "${HELLO}" "world"
+test_stop
+
+test_start "skip-env"
+  echo "[global]
+skip_dotenv = true" > "${XDG_CONFIG_HOME}/direnv/direnv.toml"
+  direnv_eval
+  test -z "${SKIPPED}"
 test_stop
 
 # Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file

--- a/test/scenarios/skip-env/.env
+++ b/test/scenarios/skip-env/.env
@@ -1,0 +1,1 @@
+SKIPPED=dotenv


### PR DESCRIPTION
The feature to automatically load .env files in https://github.com/direnv/direnv/pull/845 is nice, but it's a little too greedy in certain situations. Allow skipping that behavior by default (going back to explicit `dotenv` calls in `.envrc` files) in the configuration toml file.