### PR TITLE
Re-add accidentally deleted comment line

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -107,6 +107,7 @@ func LoadConfig(env Env) (config *Config, err error) {
 		// Declare global once and then share it between the top-level and Global
 		// keys. The goal here is to let the decoder fill global regardless of if
 		// the values are in the [global] section or not. The reason we do that is
+		// to keep backward-compatibility with the old top-level notation.
 		var global tomlGlobal
 		tomlConf := tomlConfig{
 			tomlGlobal: &global,


### PR DESCRIPTION
I was looking through [`config.go`](https://github.com/direnv/direnv/blob/f68f741895754e9551059c8e0132a796ad1c3c3a/internal/cmd/config.go), and I found a comment that was incomplete. It turned out that the final line was accidentally deleted in #573.

I can't find any development guide on things like commit message conventions or PR workflow, so I hope I am doing this correctly. Please let me know if I need to change anything.