### PR TITLE
Fix bundler not installing into local .direnv

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -957,8 +957,13 @@ layout_ruby() {
   export BUNDLE_BIN
   export GEM_HOME
 
+  mkdir -p "$GEM_HOME/bin"
+  mkdir -p "$BUNDLE_BIN"
+
   PATH_add "$GEM_HOME/bin"
   PATH_add "$BUNDLE_BIN"
+  
+  path_add GEM_PATH "$GEM_HOME"
 }
 
 # Usage: layout julia


### PR DESCRIPTION
The most important part is to add `GEM_HOME` to `GEM_PATH`, but to be extra safe also make sure that the directories exists.