### PR TITLE
doc: fix the broken link to arch linux

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ The installation has two parts.
 direnv is packaged for a variety of systems:
 
 * [Fedora](https://apps.fedoraproject.org/packages/direnv)
-* [Arch AUR](https://aur.archlinux.org/packages/direnv/)
+* [Arch Linux](https://archlinux.org/packages/community/x86_64/direnv/)
 * [Debian](https://packages.debian.org/search?keywords=direnv&searchon=names&suite=all&section=all)
 * [Gentoo go-overlay](https://github.com/Dr-Terrible/go-overlay)
 * [NetBSD pkgsrc-wip](http://www.pkgsrc.org/wip/)


### PR DESCRIPTION
The link to the arch-aur-package is dead, as this package is now available in the official repo.