### PR TITLE
Use setenv in vim to allow non alphanumeric vars

### DIFF
--- a/internal/cmd/shell_vim.go
+++ b/internal/cmd/shell_vim.go
@@ -33,16 +33,16 @@ func (sh vim) Dump(env Env) (out string) {
 }
 
 func (sh vim) export(key, value string) string {
-	return "let $" + sh.escapeKey(key) + " = " + sh.escapeValue(value) + "\n"
+	return "call setenv(" + sh.escapeKey(key) + "," + sh.escapeValue(value) + ")\n"
 }
 
 func (sh vim) unset(key string) string {
-	return "let $" + sh.escapeKey(key) + " = ''\n"
+	return "call setenv(" + sh.escapeKey(key) + ",v:null)\n"
 }
 
 // TODO: support keys with special chars or fail
 func (sh vim) escapeKey(str string) string {
-	return str
+	return sh.escapeValue(str)
 }
 
 // TODO: Make sure this escaping is valid


### PR DESCRIPTION
ref: `:h setenv()` https://vimhelp.org/builtin.txt.html#setenv%28%29

Of note, the `:h expr-env` documentation says

> The functions getenv() and setenv() can also be used and work for
> environment variables with non-alphanumeric names.
> The function environ() can be used to get a Dict with all environment
> variables.