### PR TITLE
feat: allow conda environment names to be detected from environment.yml

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -856,7 +856,19 @@ layout_anaconda() {
     env_loc="$env_name_or_prefix"
   else
     # "foo" name
-    env_name="$env_name_or_prefix"
+    # if no name was passed, try to parse it from local environment.yml
+    if [[ -n "$env_name_or_prefix" ]]; then
+      env_name="$env_name_or_prefix"
+    elif [[ -e environment.yml ]]; then
+      env_name_grep_match="$(grep -- '^name:' environment.yml)"
+      env_name="${env_name_grep_match/#name:*([[:space:]])}"
+    fi
+
+    if [[ -z "$env_name" ]]; then
+      log_error "Could not determine conda env name (set in environment.yml or pass explicitly)"
+      return 1
+    fi
+
     env_loc=$("$conda" env list | grep -- '^'"$env_name"'\s')
     env_loc="${env_loc##* }"
   fi


### PR DESCRIPTION
Currently an error is encountered if an environment name is not
specified to `layout anaconda`. This change attempts to detect
the environment name from the environment.yml file by grepping
for the `name` property and processing the result.

The result is that .envrc files can now simply contain
`layout anaconda` as long as the local environment.yml
file specifies a `name`.

No new dependencies are introduced as `grep` is already used
and additional processing is performed using Bash parameter
expansion.