### PR TITLE
Don't load .env files by default

### DIFF
--- a/internal/cmd/cmd_exec.go
+++ b/internal/cmd/cmd_exec.go
@@ -52,7 +52,7 @@ func cmdExecAction(env Env, args []string, config *Config) (err error) {
 	previousEnv.CleanContext()
 
 	// Load the rc
-	if toLoad := findEnvUp(rcPath, config.SkipDotenv); toLoad != "" {
+	if toLoad := findEnvUp(rcPath, config.LoadDotenv); toLoad != "" {
 		if newEnv, err = config.EnvFromRC(toLoad, previousEnv); err != nil {
 			return
 		}

--- a/internal/cmd/cmd_export.go
+++ b/internal/cmd/cmd_export.go
@@ -34,7 +34,7 @@ func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 
 	logDebug("loading RCs")
 	loadedRC := config.LoadedRC()
-	toLoad := findEnvUp(config.WorkDir, config.SkipDotenv)
+	toLoad := findEnvUp(config.WorkDir, config.LoadDotenv)
 
 	if loadedRC == nil && toLoad == "" {
 		return

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -25,7 +25,7 @@ type Config struct {
 	TomlPath        string
 	DisableStdin    bool
 	StrictEnv       bool
-	SkipDotenv      bool
+	LoadDotenv      bool
 	WarnTimeout     time.Duration
 	WhitelistPrefix []string
 	WhitelistExact  map[string]bool
@@ -51,7 +51,8 @@ type tomlGlobal struct {
 	BashPath     string       `toml:"bash_path"`
 	DisableStdin bool         `toml:"disable_stdin"`
 	StrictEnv    bool         `toml:"strict_env"`
-	SkipDotenv   bool         `toml:"skip_dotenv"`
+	SkipDotenv   bool         `toml:"skip_dotenv"` // deprecated, use load_dotenv
+	LoadDotenv   bool         `toml:"load_dotenv"`
 	WarnTimeout  tomlDuration `toml:"warn_timeout"`
 }
 
@@ -128,10 +129,14 @@ func LoadConfig(env Env) (config *Config, err error) {
 			config.WhitelistExact[path] = true
 		}
 
+		if tomlConf.SkipDotenv {
+			logError("skip_dotenv has been inverted to load_dotenv.")
+		}
+
 		config.BashPath = tomlConf.BashPath
 		config.DisableStdin = tomlConf.DisableStdin
+		config.LoadDotenv = tomlConf.LoadDotenv
 		config.StrictEnv = tomlConf.StrictEnv
-		config.SkipDotenv = tomlConf.SkipDotenv
 		config.WarnTimeout = tomlConf.WarnTimeout.Duration
 	}
 

--- a/internal/cmd/rc.go
+++ b/internal/cmd/rc.go
@@ -24,7 +24,7 @@ type RC struct {
 
 // FindRC looks for ".envrc" and ".env" files up in the file hierarchy.
 func FindRC(wd string, config *Config) (*RC, error) {
-	rcPath := findEnvUp(wd, config.SkipDotenv)
+	rcPath := findEnvUp(wd, config.LoadDotenv)
 	if rcPath == "" {
 		return nil, nil
 	}
@@ -287,12 +287,11 @@ func allow(path string, allowPath string) (err error) {
 	return ioutil.WriteFile(allowPath, []byte(path+"\n"), 0644)
 }
 
-func findEnvUp(searchDir string, skipDotenv bool) (path string) {
-	if skipDotenv {
-		return findUp(searchDir, ".envrc")
+func findEnvUp(searchDir string, loadDotenv bool) (path string) {
+	if loadDotenv {
+		return findUp(searchDir, ".envrc", ".env")
 	}
-
-	return findUp(searchDir, ".envrc", ".env")
+	return findUp(searchDir, ".envrc")
 }
 
 func findUp(searchDir string, fileNames ...string) (path string) {

--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -10,7 +10,7 @@ direnv-stdlib - functions for the \fB\fC\&.envrc\fR
 
 .SH DESCRIPTION
 .PP
-Outputs a bash script called the \fIstdlib\fP\&. The following commands are included in that script and loaded in the context of an \fB\fC\&.envrc\fR\&. In addition, it also loads the file in \fB\fC~/.direnvrc\fR if it exists.
+Outputs a bash script called the \fIstdlib\fP\&. The following commands are included in that script and loaded in the context of an \fB\fC\&.envrc\fR\&. In addition, it also loads the file in \fB\fC~/.config/direnv/direnvrc\fR if it exists.
 
 .SH STDLIB
 .SS \fB\fChas <command>\fR

--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -52,9 +52,9 @@ This allows one to hard-code the position of bash. It maybe be useful to set thi
 .PP
 If set to \fB\fCtrue\fR, stdin is disabled (redirected to /dev/null) during the \fB\fC\&.envrc\fR evaluation.
 
-.SS \fB\fCskip_dotenv\fR
+.SS \fB\fCload_dotenv\fR
 .PP
-Don't look for \fB\fC\&.env\fR files, only \fB\fC\&.envrc\fR files.
+Also look for and load \fB\fC\&.env\fR files on top of the \fB\fC\&.envrc\fR files.
 
 .SS \fB\fCstrict_env\fR
 .PP

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -42,9 +42,9 @@ This allows one to hard-code the position of bash. It maybe be useful to set thi
 
 If set to `true`, stdin is disabled (redirected to /dev/null) during the `.envrc` evaluation.
 
-### `skip_dotenv`
+### `load_dotenv`
 
-Don't look for `.env` files, only `.envrc` files.
+Also look for and load `.env` files on top of the `.envrc` files.
 
 ### `strict_env`
 

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -235,13 +235,14 @@ test_start "load-envrc-before-env"
 test_stop
 
 test_start "load-env"
+  echo "[global]
+load_dotenv = true" > "${XDG_CONFIG_HOME}/direnv/direnv.toml"
+  direnv allow
   direnv_eval
   test_eq "${HELLO}" "world"
 test_stop
 
 test_start "skip-env"
-  echo "[global]
-skip_dotenv = true" > "${XDG_CONFIG_HOME}/direnv/direnv.toml"
   direnv_eval
   test -z "${SKIPPED}"
 test_stop


### PR DESCRIPTION
Loading the `.env` files is a change in behaviour and broke
backward-compatibility. It sounds really nice at first but it turns out
that many users have .env files littered in their repository and cause a
direnv reload. It's possible to turn that feature off but now they have
one extra step to instruct their users.

This commit inverts the behaviour and turns that feature off by default
to restore back-compat.

See also #878.