### PR TITLE
installation.md: Fix Fedora package link

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ The installation has two parts.
 
 direnv is packaged for a variety of systems:
 
-* [Fedora](https://apps.fedoraproject.org/packages/direnv)
+* [Fedora](https://src.fedoraproject.org/rpms/direnv)
 * [Arch Linux](https://archlinux.org/packages/community/x86_64/direnv/)
 * [Debian](https://packages.debian.org/search?keywords=direnv&searchon=names&suite=all&section=all)
 * [Gentoo go-overlay](https://github.com/Dr-Terrible/go-overlay)


### PR DESCRIPTION
The old apps.fedoraproject.org is no more! Update the Fedora package link to point to the new location for the direnv package.