### PR TITLE
source_up_if_exists: A strict_env compatible version of source_up

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -149,7 +149,16 @@ env_vars_required GITHUB_TOKEN OTHER_TOKEN
 
 .SS \fB\fCsource_up [<filename>]\fR
 .PP
-Loads another \fB\fC\&.envrc\fR if found when searching from the parent directory up to /.
+Loads another \fB\fC\&.envrc\fR if found with the find_up command. Returns 1 if no file
+is found.
+
+.PP
+NOTE: the other \fB\fC\&.envrc\fR is not checked by the security framework.
+
+.SS \fB\fCsource_up_if_exists [<filename>]\fR
+.PP
+Loads another \fB\fC\&.envrc\fR if found with the find_up command. If one is not
+found, nothing happens.
 
 .PP
 NOTE: the other \fB\fC\&.envrc\fR is not checked by the security framework.

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -418,14 +418,32 @@ watch_dir() {
 
 # Usage: source_up [<filename>]
 #
-# Loads another ".envrc" if found with the find_up command.
+# Loads another ".envrc" if found with the find_up command. Returns 1 if no
+# file is found.
 #
 # NOTE: the other ".envrc" is not checked by the security framework.
 source_up() {
-  local dir file=${1:-.envrc}
-  dir=$(cd .. && find_up "$file")
-  if [[ -n $dir ]]; then
-    source_env "$dir"
+  local envrc file=${1:-.envrc}
+  envrc=$(cd .. && (find_up "$file" || true))
+  if [[ -n $envrc ]]; then
+    source_env "$envrc"
+  else
+    log_error "No ancestor $file found"
+    exit 1
+  fi
+}
+
+# Usage: source_up_if_exists [<filename>]
+#
+# Loads another ".envrc" if found with the find_up command. If one is not
+# found, nothing happens.
+#
+# NOTE: the other ".envrc" is not checked by the security framework.
+source_up_if_exists() {
+  local envrc file=${1:-.envrc}
+  envrc=$(cd .. && (find_up "$file" || true))
+  if [[ -n $envrc ]]; then
+    source_env "$envrc"
   fi
 }
 

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -418,21 +418,20 @@ watch_dir() {
 
 # Usage: _source_up [<filename>] [true|false]
 #
-# Helper function for source_up and source_up_if_exists. The second parameter
-# determines if it's an error for the file we're searching for to not exist.
+# Private helper function for source_up and source_up_if_exists. The second
+# parameter determines if it's an error for the file we're searching for to
+# not exist.
 _source_up() {
   local envrc file=${1:-.envrc}
   local ok_if_not_exist=${2}
   envrc=$(cd .. && (find_up "$file" || true))
   if [[ -n $envrc ]]; then
     source_env "$envrc"
+  elif $ok_if_not_exist; then
+    return 0
   else
-    if $ok_if_not_exist; then
-      return 0
-    else
-      log_error "No ancestor $file found"
-      return 1
-    fi
+    log_error "No ancestor $file found"
+    return 1
   fi
 }
 
@@ -443,7 +442,7 @@ _source_up() {
 #
 # NOTE: the other ".envrc" is not checked by the security framework.
 source_up() {
-  _source_up "${1:-1}" false
+  _source_up "${1:-}" false
 }
 
 # Usage: source_up_if_exists [<filename>]
@@ -453,7 +452,7 @@ source_up() {
 #
 # NOTE: the other ".envrc" is not checked by the security framework.
 source_up_if_exists() {
-  _source_up "${1:-1}" true
+  _source_up "${1:-}" true
 }
 
 # Usage: fetchurl <url> [<integrity-hash>]


### PR DESCRIPTION
This fixes https://github.com/direnv/direnv/issues/913

While I was in here, I opted to make the existing `source_up` script log
explicitly when it can't find a file. I think that's useful both with
strict_env enabled and disabled.