### PR TITLE
Add convenient aliases for allow/deny commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+UNRELEASED / 2022-04-??
+==================
+  * Add "block" and "revoke" as aliases of the "deny" command (#935)
+  * Add "permit" and "grant" as aliases of the "allow" command (#935)
 
 2.31.0 / 2022-03-26
 ==================

--- a/internal/cmd/cmd_allow.go
+++ b/internal/cmd/cmd_allow.go
@@ -8,10 +8,11 @@ import (
 
 // CmdAllow is `direnv allow [PATH_TO_RC]`
 var CmdAllow = &Cmd{
-	Name:   "allow",
-	Desc:   "Grants direnv to load the given .envrc or .env",
-	Args:   []string{"[PATH_TO_RC]"},
-	Action: actionWithConfig(cmdAllowAction),
+	Name:    "allow",
+	Desc:    "Grants direnv permission to load the given .envrc or .env file.",
+	Args:    []string{"[PATH_TO_RC]"},
+	Aliases: []string{"permit", "grant"},
+	Action:  actionWithConfig(cmdAllowAction),
 }
 
 var migrationMessage = `

--- a/internal/cmd/cmd_deny.go
+++ b/internal/cmd/cmd_deny.go
@@ -8,10 +8,11 @@ import (
 
 // CmdDeny is `direnv deny [PATH_TO_RC]`
 var CmdDeny = &Cmd{
-	Name:   "deny",
-	Desc:   "Revokes the authorization of a given .envrc or .env",
-	Args:   []string{"[PATH_TO_RC]"},
-	Action: actionWithConfig(cmdDenyAction),
+	Name:    "block",
+	Desc:    "Revokes the authorization of a given .envrc or .env file.",
+	Args:    []string{"[PATH_TO_RC]"},
+	Aliases: []string{"deny", "revoke"},
+	Action:  actionWithConfig(cmdDenyAction),
 }
 
 func cmdDenyAction(env Env, args []string, config *Config) (err error) {

--- a/internal/cmd/cmd_help.go
+++ b/internal/cmd/cmd_help.go
@@ -29,7 +29,13 @@ Available commands
 					fmt.Printf("*%s%s:\n  %s\n", cmd.Name, opts, cmd.Desc)
 				}
 			} else {
-				fmt.Printf("%s%s:\n  %s\n", cmd.Name, opts, cmd.Desc)
+				fmt.Printf("%s%s:\n", cmd.Name, opts)
+				for _, alias := range cmd.Aliases {
+					if alias[0:1] != "-" {
+						fmt.Printf("%s%s:\n", alias, opts)
+					}
+				}
+				fmt.Printf("  %s\n", cmd.Desc)
 			}
 		}
 

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -247,6 +247,15 @@ test_start "skip-env"
   test -z "${SKIPPED}"
 test_stop
 
+test_start "aliases"
+  direnv deny
+  # check that allow/deny aliases work
+  direnv permit && direnv_eval && test -n "${HELLO}"
+  direnv block  && direnv_eval && test -z "${HELLO}"
+  direnv grant  && direnv_eval && test -n "${HELLO}"
+  direnv revoke && direnv_eval && test -z "${HELLO}"
+test_stop
+
 # Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file
 # BUG: foo/bar is resolved in the .envrc execution context and so can't find
 #      the .envrc file.

--- a/test/scenarios/aliases/.envrc
+++ b/test/scenarios/aliases/.envrc
@@ -1,0 +1,1 @@
+export HELLO=world


### PR DESCRIPTION
It's easy to forget the correct command name -- so support them all!

 - allow  / block
 - permit / deny
 - grant  / revoke

Closes #832
