### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [ master ]
   pull_request: {}
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [ master ]
   pull_request: {}
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,13 @@ on:
 # TODO: also publish the dist
 name: Create Release
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     name: Create Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
