### PR TITLE
Enable ppc64le builds

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -169,6 +169,7 @@ dist:
 		-osarch linux/mips64le \
 		-osarch linux/mipsle \
 		-osarch linux/ppc64 \
+		-osarch linux/ppc64le \
 		-osarch linux/s390x \
 		-osarch netbsd/386 \
 		-osarch netbsd/amd64 \


### PR DESCRIPTION
Currently, only big-endian PowerPC builds are provided.
This commit enables little-endian PowerPC builds as well.

Little-endian PowerPC is the default for all "modern" PowerPC
offerings by IBM and arguably the more common PowerPC variant
today.