### PR TITLE
fix: remove try block

### DIFF
--- a/internal/cmd/shell_elvish.go
+++ b/internal/cmd/shell_elvish.go
@@ -13,20 +13,16 @@ var Elvish Shell = elvish{}
 func (elvish) Hook() (string, error) {
 	return `## hook for direnv
 set @edit:before-readline = $@edit:before-readline {
-	try {
-		var m = [("{{.SelfPath}}" export elvish | from-json)]
-		if (> (count $m) 0) {
-			set m = (all $m)
-			keys $m | each { |k|
-				if $m[$k] {
-					set-env $k $m[$k]
-				} else {
-					unset-env $k
-				}
+	var m = [("{{.SelfPath}}" export elvish | from-json)]
+	if (> (count $m) 0) {
+		set m = (all $m)
+		keys $m | each { |k|
+			if $m[$k] {
+				set-env $k $m[$k]
+			} else {
+				unset-env $k
 			}
 		}
-	} except e {
-		echo $e
 	}
 }
 `, nil


### PR DESCRIPTION
`try {} except e {}` is now deprecated (elvish v0.18.0) and will be
removed in the next version - 0.19.0.

Since direnv will most probably run in pre-0.18.0 elvish
environments it is maybe for the best to remove the try block.

As far as I can see - its use is to catch exceptions from running
`direnv export elvish`, which should only happen if direnv vanishes
from the user's path. Any other error should most probably fail
anyway, rather than echo the exception but proceed.