### PR TITLE
Update layout anaconda to accept a path to a yml file

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -863,17 +863,26 @@ layout_python3() {
   layout_python python3 "$@"
 }
 
-# Usage: layout anaconda <env_name_or_prefix> [<conda_exe>]
+# Usage: layout anaconda <env_spec> [<conda_exe>]
 #
-# Activates anaconda for the named environment or prefix. If the environment
-# hasn't been created, it will be using the environment.yml file in
-# the current directory. <conda_exe> is optional and will default to
-# the one found in the system environment.
+# Activates anaconda for the provided environment.
+# The <env_spec> can be one of the following:
+#   1. Name of an environment
+#   2. Prefix path to an environment
+#   3. Path to a yml-formatted file specifying the environment
+#
+# Environment creation will use environment.yml, if
+# available, when a name or prefix is provided. Otherwise,
+# an empty environment will be created.
+#
+# <conda_exe> is optional and will default to the one
+# found in the system environment.
 #
 layout_anaconda() {
-  local env_name_or_prefix=$1
+  local env_spec=$1
   local env_name
   local env_loc
+  local env_config
   local conda
   local REPLY
   if [[ $# -gt 1 ]]; then
@@ -883,44 +892,70 @@ layout_anaconda() {
   fi
   realpath.dirname "$conda"
   PATH_add "$REPLY"
-  if [[ "${env_name_or_prefix%%/*}" == "." ]]; then
-    # "./foo" relative prefix
-    realpath.absolute "$env_name_or_prefix"
-    env_loc="$REPLY"
-  elif [[ ! "$env_name_or_prefix" == "${env_name_or_prefix#/}" ]]; then
-    # "/foo" absolute prefix
-    env_loc="$env_name_or_prefix"
-  else
-    # "foo" name
-    # if no name was passed, try to parse it from local environment.yml
-    if [[ -n "$env_name_or_prefix" ]]; then
-      env_name="$env_name_or_prefix"
-    elif [[ -e environment.yml ]]; then
-      env_name_grep_match="$(grep -- '^name:' environment.yml)"
-      env_name="${env_name_grep_match/#name:*([[:space:]])}"
-    fi
 
-    if [[ -z "$env_name" ]]; then
-      log_error "Could not determine conda env name (set in environment.yml or pass explicitly)"
+  if [[ "${env_spec##*.}" == "yml" ]]; then
+    env_config=$env_spec
+  elif [[ "${env_spec%%/*}" == "." ]]; then
+    # "./foo" relative prefix
+    realpath.absolute "$env_spec"
+    env_loc="$REPLY"
+  elif [[ ! "$env_spec" == "${env_spec#/}" ]]; then
+    # "/foo" absolute prefix
+    env_loc="$env_spec"
+  elif [[ -n "$env_spec" ]]; then
+    # "name" specified
+    env_name="$env_spec"
+  else
+    # Need at least one
+    env_config=environment.yml
+  fi
+
+  # If only config, it needs a name field
+  if [[ -n "$env_config" ]]; then
+    if [[ -e "$env_config" ]]; then
+      env_name="$(grep -- '^name:' $env_config)"
+      env_name="${env_name/#name:*([[:space:]])}"
+      if [[ -z "$env_name" ]]; then
+        log_error "Unable to find 'name' in '$env_config'"
+        return 1
+      fi
+    else
+      log_error "Unable to find config '$env_config'"
       return 1
     fi
+  fi
 
+  # Try to find location based on name
+  if [[ -z "$env_loc" ]]; then
+    # Update location if already created
     env_loc=$("$conda" env list | grep -- '^'"$env_name"'\s')
     env_loc="${env_loc##* }"
   fi
+
+  # Check for environment existence
   if [[ ! -d "$env_loc" ]]; then
-    if [[ -e environment.yml ]]; then
-      log_status "creating conda environment"
-      if [[ -n "$env_name" ]]; then
-        "$conda" env create --name "$env_name"
-        env_loc=$("$conda" env list | grep -- '^'"$env_name"'\s')
-        env_loc="/${env_loc##* /}"
+
+    # Create if necessary
+    if [[ -z "$env_config" ]] && [[ -n "$env_name" ]]; then
+      if [[ -e environment.yml ]]; then
+        "$conda" env create --file environment.yml --name "$env_name"
       else
-        "$conda" env create --prefix "$env_loc"
+        "$conda" create -y --name "$env_name"
       fi
-    else
-      log_error "Could not find environment.yml"
-      return 1
+    elif [[ -n "$env_config" ]]; then
+      "$conda" env create --file "$env_config"
+    elif [[ -n "$env_loc" ]]; then
+      if [[ -e environment.yml ]]; then
+        "$conda" env create --file environment.yml --prefix "$env_loc"
+      else
+        "$conda" create -y --prefix "$env_loc"
+      fi
+    fi
+
+    if [[ -z "$env_loc" ]]; then
+      # Update location if already created
+      env_loc=$("$conda" env list | grep -- '^'"$env_name"'\s')
+      env_loc="${env_loc##* }"
     fi
   fi
 


### PR DESCRIPTION
Conda assumes the environment config is provided by
environment.yml when the --file argument is not
provided. This allows for specifying a path to
a different file. For example, a project that has
a two environment definitions based on host platform.

Some of the projects I work with don't use environment.yml
in the root directory. I've been using this in my direnvrc to
handle it.