### PR TITLE
Add stdlib pyenv docs

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -353,6 +353,13 @@ Similar to \fB\fClayout python\fR, but uses Pipenv to build a virtualenv from th
 .PP
 Note that unlike invoking Pipenv manually, this does not load environment variables from a \fB\fC\&.env\fR file automatically. You may want to add \fB\fCdotenv .env\fR to copy that behavior.
 
+.SS \fB\fClayout pyenv [<version> ...]\fR
+.PP
+Similar to \fB\fClayout python\fR, but uses pyenv to build a virtualenv with the specified Python interpreter version.
+
+.PP
+Multiple versions may be specified separated by spaces; please refer to the pyenv documentation for more information.
+
 .SS \fB\fClayout python [<python_exe>]\fR
 .PP
 Creates and loads a virtualenv environment under \fB\fC$PWD/.direnv/python-$python_version\fR\&. This forces the installation of any egg into the project's sub-folder.

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -255,6 +255,12 @@ Similar to `layout python`, but uses Pipenv to build a virtualenv from the `Pipf
 
 Note that unlike invoking Pipenv manually, this does not load environment variables from a `.env` file automatically. You may want to add `dotenv .env` to copy that behavior.
 
+### `layout pyenv [<version> ...]`
+
+Similar to `layout python`, but uses pyenv to build a virtualenv with the specified Python interpreter version.
+
+Multiple versions may be specified separated by spaces; please refer to the pyenv documentation for more information.
+
 ### `layout python [<python_exe>]`
 
 Creates and loads a virtualenv environment under `$PWD/.direnv/python-$python_version`. This forces the installation of any egg into the project's sub-folder.

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -105,7 +105,15 @@ Example:
 
 ### `source_up [<filename>]`
 
-Loads another `.envrc` if found when searching from the parent directory up to /.
+Loads another `.envrc` if found with the find_up command. Returns 1 if no file
+is found.
+
+NOTE: the other `.envrc` is not checked by the security framework.
+
+### `source_up_if_exists [<filename>]`
+
+Loads another `.envrc` if found with the find_up command. If one is not
+found, nothing happens.
 
 NOTE: the other `.envrc` is not checked by the security framework.
 


### PR DESCRIPTION
It appears to me that `layout pyenv` is not mentioned in the stdlib manpage.

Also sync omissions to `man/direnv-stdlib.1.md` from manual changes to `man/direnv-stdlib.1` (https://github.com/direnv/direnv/pull/921).