### PR TITLE
fix path escaping

### DIFF
--- a/internal/cmd/rc.go
+++ b/internal/cmd/rc.go
@@ -185,11 +185,11 @@ func (rc *RC) Load(previousEnv Env) (newEnv Env, err error) {
 	}
 
 	arg := fmt.Sprintf(
-		`%seval "$("%s" stdlib)" && __main__ %s "%s"`,
+		`%seval "$("%s" stdlib)" && __main__ %s %s`,
 		prelude,
 		direnv,
 		fn,
-		rc.Path(),
+		BashEscape(rc.Path()),
 	)
 
 	// G204: Subprocess launched with function call as argument or cmd arguments

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -280,6 +280,12 @@ test_start "aliases"
   direnv revoke && direnv_eval && test -z "${HELLO}"
 test_stop
 
+# shellcheck disable=SC2016
+test_start '$test'
+  direnv_eval
+  [[ $FOO = bar ]]
+test_stop
+
 # Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file
 # BUG: foo/bar is resolved in the .envrc execution context and so can't find
 #      the .envrc file.

--- a/test/scenarios/$test/.envrc
+++ b/test/scenarios/$test/.envrc
@@ -1,0 +1,1 @@
+export FOO=bar


### PR DESCRIPTION
If a path would include $, it was getting expanded during the
evaluation.

Reported by Fabian Thorand