### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/docs/hook.md
+++ b/docs/hook.md
@@ -40,6 +40,16 @@ set -g direnv_fish_mode eval_after_arrow # trigger direnv at prompt, and only af
 set -g direnv_fish_mode disable_arrow    # trigger direnv at prompt only, this is similar functionality to the original behavior
 ```
 
+## Autocomplete
+
+You can get IDE-style autocompletions for direnv with <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a> [Fig](https://fig.io/). It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
 ## TCSH
 
 Add the following line at the end of the `~/.cshrc` file:


### PR DESCRIPTION
[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including direnv. It looks like this:

<img width="391" alt="image" src="https://user-images.githubusercontent.com/4949076/181604877-dec5f46f-d65d-4b7d-8399-d9a080a854c6.png">

We think this will help users become more efficient with direnv CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!