### PR TITLE
elvish: replace deprecated `except` with `catch`

### DIFF
--- a/internal/cmd/shell_elvish.go
+++ b/internal/cmd/shell_elvish.go
@@ -25,7 +25,7 @@ set @edit:before-readline = $@edit:before-readline {
 				}
 			}
 		}
-	} except e {
+	} catch e {
 		echo $e
 	}
 }


### PR DESCRIPTION
https://elv.sh/blog/0.18.0-release-notes.html#deprecated-features

fix #902 
related #914 