### PR TITLE
fix(test): use lowercase -d flag for base64 decoding of DIRENV_DIFF

### DIFF
--- a/test/show-direnv-diff.sh
+++ b/test/show-direnv-diff.sh
@@ -5,4 +5,4 @@
 
 GZIP_HEADER="\x1f\x8b\x08\x00\x00\x00\x00\x00"
 
-(printf $GZIP_HEADER; echo $DIRENV_DIFF | base64 -D) | gzip -dc | python -mjson.tool
+(printf $GZIP_HEADER; echo $DIRENV_DIFF | base64 -d) | gzip -dc | python -mjson.tool


### PR DESCRIPTION
Hello

Coreutils' `base64` program has no `-D` flag (uppercase) to decode data : https://man.archlinux.org/man/base64.1

Thanks