### PR TITLE
Syntax highlighting for fish shell

### DIFF
--- a/docs/hook.md
+++ b/docs/hook.md
@@ -28,13 +28,13 @@ eval "$(direnv hook zsh)"
 
 Add the following line at the end of the `~/.config/fish/config.fish` file:
 
-```fish
+```sh
 direnv hook fish | source
 ```
 
 Fish supports 3 modes you can set with the global environment variable `direnv_fish_mode`:
 
-```fish
+```sh
 set -g direnv_fish_mode eval_on_arrow    # trigger direnv at prompt, and on every arrow-based directory change (default)
 set -g direnv_fish_mode eval_after_arrow # trigger direnv at prompt, and only after arrow-based directory changes before executing command
 set -g direnv_fish_mode disable_arrow    # trigger direnv at prompt only, this is similar functionality to the original behavior


### PR DESCRIPTION
The `fish` language selector in fenced code blocks adds a `>` at the beginning of the first line (see screenshot below) which is a bit confusing when copy/pasting, I think its better without it.

![image](https://user-images.githubusercontent.com/52666720/208071935-27c9fe75-a27a-47bc-bb45-dec0abfae518.png)
