### PR TITLE
Avoid use of regex in bash hook output

### DIFF
--- a/internal/cmd/shell_bash.go
+++ b/internal/cmd/shell_bash.go
@@ -15,7 +15,7 @@ _direnv_hook() {
   trap - SIGINT;
   return $previous_exit_status;
 };
-if ! [[ "${PROMPT_COMMAND[*]:-}" =~ _direnv_hook ]]; then
+if [[ ";${PROMPT_COMMAND[*]:-};" != *";_direnv_hook;"* ]]; then
   if [[ "$(declare -p PROMPT_COMMAND 2>&1)" == "declare -a"* ]]; then
     PROMPT_COMMAND=(_direnv_hook "${PROMPT_COMMAND[@]}")
   else


### PR DESCRIPTION
Not that this would be performance critical, but in principle.

Also makes the match test more exact, rather than hitting anything with a `_direnv_hook` substring.