### PR TITLE
Stat the already open rc file rather than another path based one on it

### DIFF
--- a/internal/cmd/rc.go
+++ b/internal/cmd/rc.go
@@ -246,10 +246,10 @@ func fileExists(path string) bool {
 	if err != nil {
 		return false
 	}
-	f.Close()
+	defer f.Close()
 
 	// Next, check that the file is a regular file.
-	fi, err := os.Stat(path)
+	fi, err := f.Stat()
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
Seems slightly more performant (unsure if measurable in practice) and cleaner this way.