### PR TITLE
stdlib: use_guix: Switch to guix shell.

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -449,13 +449,13 @@ will have to enable on your own. Flakes is not considered stable yet.
 
 .SS \fB\fCuse guix [...]\fR
 .PP
-Load environment variables from \fB\fCguix environment\fR\&.
+Load environment variables from \fB\fCguix shell\fR\&.
 
 .PP
-Any arguments given will be passed to guix environment. For example, \fB\fCuse guix hello\fR would setup an environment with the dependencies of the hello package. To create an environment including hello, the \fB\fC--ad-hoc\fR flag is used \fB\fCuse guix --ad-hoc hello\fR\&. Other options include \fB\fC--load\fR which allows loading an environment from a file.
+Any arguments given will be passed to guix shell. For example, \fB\fCuse guix hello\fR would setup an environment including the hello package. To create an environment with the hello dependencies, the \fB\fC--development\fR flag is used \fB\fCuse guix --development hello\fR\&. Other options include \fB\fC--file\fR which allows loading an environment from a file.
 
 .PP
-See https://www.gnu.org/software/guix/manual/html_node/Invoking-guix-environment.html
+See https://guix.gnu.org/en/manual/en/guix.html#Invoking-guix-shell
 
 .SS \fB\fCrvm [...]\fR
 .PP

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -328,11 +328,11 @@ will have to enable on your own. Flakes is not considered stable yet.
 
 ### `use guix [...]`
 
-Load environment variables from `guix environment`.
+Load environment variables from `guix shell`.
 
-Any arguments given will be passed to guix environment. For example, `use guix hello` would setup an environment with the dependencies of the hello package. To create an environment including hello, the `--ad-hoc` flag is used `use guix --ad-hoc hello`. Other options include `--load` which allows loading an environment from a file.
+Any arguments given will be passed to guix shell. For example, `use guix hello` would setup an environment including the hello package. To create an environment with the hello dependencies, the `--development` flag is used `use guix --development hello`. Other options include `--file` which allows loading an environment from a file.
 
-See https://www.gnu.org/software/guix/manual/html_node/Invoking-guix-environment.html
+See https://guix.gnu.org/en/manual/en/guix.html#Invoking-guix-shell
 
 ### `rvm [...]`
 

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1272,16 +1272,16 @@ use_flake() {
 
 # Usage: use_guix [...]
 #
-# Load environment variables from `guix environment`.
-# Any arguments given will be passed to guix environment. For example,
-# `use guix hello` would setup an environment with the dependencies of
-# the hello package. To create an environment including hello, the
-# `--ad-hoc` flag is used `use guix --ad-hoc hello`. Other options
-# include `--load` which allows loading an environment from a
+# Load environment variables from `guix shell`.
+# Any arguments given will be passed to guix shell. For example,
+# `use guix hello` would setup an environment including the hello
+# package. To create an environment with the hello dependencies, the
+# `--development` flag is used `use guix --development hello`. Other
+# options include `--file` which allows loading an environment from a
 # file. For a full list of options, consult the documentation for the
-# `guix environment` command.
+# `guix shell` command.
 use_guix() {
-  eval "$(guix environment "$@" --search-paths)"
+  eval "$(guix shell "$@" --search-paths)"
 }
 
 # Usage: use_vim [<vimrc_file>]


### PR DESCRIPTION
This patch switches the use_guix behavior to the new version of guix environment, which became the new supported method to spawn on-the-fly environments since the 1.4.0 Guix release.