### PR TITLE
stdlib: add direnv_leaf_dir function

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -110,6 +110,19 @@ unstrict_env() {
   fi
 }
 
+# Usage: direnv_leaf_dir
+#
+# Prints the folder where direnv's _leaf_ .envrc file is located. This
+# will not change even when source_up is used, unlike `direnv_layout_dir`
+# which can be overridden by setting a variable. Both $PWD and
+# `direnv_layout_dir` can change during execution; this one cannot.
+#
+# The output is always the directory where the closest .envrc file is found.
+__direnv_leaf_dir=${__direnv_leaf_dir:-$PWD}
+direnv_leaf_dir() {
+  echo "${__direnv_leaf_dir}"
+}
+
 # Usage: direnv_layout_dir
 #
 # Prints the folder path that direnv should use to store layout content.


### PR DESCRIPTION
The purpose here is so that .envrc files that are invoked via
`source_up` can make use of the location of the outermost (leaf?)
.envrc, specifically its location.

For example, I am using this in a synced folder's top level .envrc:

``` shell
db_root=$(realpath --relative-to "$HOME/Dropbox" "$(direnv_leaf_dir)")
if [[ $db_root == "." ]]; then
    db_root=Dropbox
fi
direnv_layout_dir="$HOME/.local/var/direnv/$db_root"
```

This lets me move my `.direnv` directories out of the sync, because the sync
directories are platform-specific but my Dropbox gets used on different CPU
architectures and OSs.

## Docs 

I didn't add stdlib docs because I didn't see the `direnv_layout_dir` function documented there either. I'm happy to add both.

## Changelog 

Same as with the docs; I can add this to the changelog, just tell me how you want it formatted and I'll update the PR.

## Testing 

I did not see any obvious place to add tests for the stdlib functions. If there is one, I'll happily add some.