### PR TITLE
Allow disabling direnv from further modifying the environment

### DIFF
--- a/internal/cmd/cmd_export.go
+++ b/internal/cmd/cmd_export.go
@@ -21,6 +21,12 @@ func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 	log.SetPrefix(log.Prefix() + "export:")
 	logDebug("start")
 
+	_, set := currentEnv["DIRENV_DISABLE"]
+	if set {
+		logDebug("direnv is disabled by environment variable")
+		return nil
+	}
+
 	var target string
 
 	if len(args) > 1 {


### PR DESCRIPTION
When DIRENV_DISABLE environment variable is set, direnv stops manipulating environment variables. When DIRENV_DISABLE environment variable is unset again, direnv picks up from where it left off and start managing the environment variables again.

Keep in mind that setting this variable doesn't unset the variables that direnv has set in the environment, it just toggles direnv, it doesn't roll back all of the effects it has done before the environment variable is set.

Fixes #550