### PR TITLE
Fix using PWD in .env files

### DIFF
--- a/internal/cmd/cmd_dotenv.go
+++ b/internal/cmd/cmd_dotenv.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
+	"path/filepath"
 	"fmt"
 	"os"
-
 	"github.com/direnv/direnv/v2/pkg/dotenv"
 )
 
@@ -42,7 +42,20 @@ func cmdDotEnvAction(_ Env, args []string) (err error) {
 	if data, err = os.ReadFile(target); err != nil {
 		return
 	}
-
+	// Set PWD env var to the directory the .env file resides in This results in
+	// the least amount of surprise, as a dotenv file is most often defined
+	// in the same directory it's loaded from, so refering to PWD should
+	// match the directory of the dotenv file.
+	path, err := filepath.Abs(target)
+	if err != nil {
+		return err
+	}
+	path, err = filepath.EvalSymlinks(path)
+	if err != nil {
+		return err
+	}
+	pwd := filepath.Dir(path)
+	os.Setenv("PWD", pwd)
 	newenv, err = dotenv.Parse(string(data))
 	if err != nil {
 		return err

--- a/internal/cmd/cmd_dotenv.go
+++ b/internal/cmd/cmd_dotenv.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"path/filepath"
 	"fmt"
-	"os"
 	"github.com/direnv/direnv/v2/pkg/dotenv"
+	"os"
+	"path/filepath"
 )
 
 // CmdDotEnv is `direnv dotenv [SHELL [PATH_TO_DOTENV]]`
@@ -42,20 +42,17 @@ func cmdDotEnvAction(_ Env, args []string) (err error) {
 	if data, err = os.ReadFile(target); err != nil {
 		return
 	}
-	// Set PWD env var to the directory the .env file resides in This results in
-	// the least amount of surprise, as a dotenv file is most often defined
-	// in the same directory it's loaded from, so refering to PWD should
-	// match the directory of the dotenv file.
+
+	// Set PWD env var to the directory the .env file resides in. This results
+	// in the least amount of surprise, as a dotenv file is most often defined
+	// in the same directory it's loaded from, so referring to PWD should match
+	// the directory of the .env file.
 	path, err := filepath.Abs(target)
 	if err != nil {
 		return err
 	}
-	path, err = filepath.EvalSymlinks(path)
-	if err != nil {
-		return err
-	}
-	pwd := filepath.Dir(path)
-	os.Setenv("PWD", pwd)
+	os.Setenv("PWD", filepath.Dir(path))
+
 	newenv, err = dotenv.Parse(string(data))
 	if err != nil {
 		return err


### PR DESCRIPTION
This change introduces PWD support to the `dotenv` functionality, so that it can resolve PWD in `.env` files.

When .env is loaded, PWD will be set to the same folder that .env file can be found in variable can be used.
A user would also expect that the PWD variable is matching the folder that the .env file resides in, and symlinks should not interfere with that either.

Fixes #1051