### PR TITLE
+1 use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ current directory.
 * Load 12factor apps environment variables
 * Create per-project isolated development environments
 * Load secrets for deployment
+* Can be used as a replacement for all known terraform wrappers
 
 ## How it works
 


### PR DESCRIPTION
We are using direnv as a replacement for [terragrunt](https://terragrunt.gruntwork.io/).
More details can be found [here](https://medium.com/@senior-devops/how-to-extend-terraform-with-direnv-a4a3fef092c5).