### PR TITLE
Add shell setup instructions for oh-my-zsh

### DIFF
--- a/docs/hook.md
+++ b/docs/hook.md
@@ -24,6 +24,16 @@ Add the following line at the end of the `~/.zshrc` file:
 eval "$(direnv hook zsh)"
 ```
 
+## Oh my zsh
+
+Oh my zsh has [a core plugin with direnv](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/direnv) support.
+
+Add direnv to the plugins array in your zshrc file:
+
+```sh
+plugins=(... direnv)
+```
+
 ## FISH
 
 Add the following line at the end of the `~/.config/fish/config.fish` file:


### PR DESCRIPTION
The plugin is a bit easier to configure, and what oh-my-zsh users are more used to.