### PR TITLE
stdlib: use_node: strip leading v from version

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1185,6 +1185,8 @@ use_node() {
     via=".node-version"
   fi
 
+  version=${version#v}
+
   if [[ -z $version ]]; then
     log_error "I do not know which NodeJS version to load because one has not been specified!"
     return 1


### PR DESCRIPTION
In line with [this helpfully compiled information on usage of .node-version files' suggested compatible format of .node-version files](https://github.com/shadowspawn/node-version-usage#suggested-compatible-format), it would be helpful for direnv to strip off leading `v` prefixes of a version specifier for broader compatability.