### PR TITLE
Update zsh syntax in internal/cmd/shell_zsh.go

### DIFF
--- a/internal/cmd/shell_zsh.go
+++ b/internal/cmd/shell_zsh.go
@@ -8,17 +8,17 @@ var Zsh Shell = zsh{}
 
 const zshHook = `
 _direnv_hook() {
-  trap -- '' SIGINT;
-  eval "$("{{.SelfPath}}" export zsh)";
-  trap - SIGINT;
+  trap -- '' SIGINT
+  eval "$("{{.SelfPath}}" export zsh)"
+  trap - SIGINT
 }
-typeset -ag precmd_functions;
-if [[ -z "${precmd_functions[(r)_direnv_hook]+1}" ]]; then
-  precmd_functions=( _direnv_hook ${precmd_functions[@]} )
+typeset -ag precmd_functions
+if (( ! ${precmd_functions[(I)_direnv_hook]} )); then
+  precmd_functions=(_direnv_hook $precmd_functions)
 fi
-typeset -ag chpwd_functions;
-if [[ -z "${chpwd_functions[(r)_direnv_hook]+1}" ]]; then
-  chpwd_functions=( _direnv_hook ${chpwd_functions[@]} )
+typeset -ag chpwd_functions
+if (( ! ${chpwd_functions[(I)_direnv_hook]} )); then
+  chpwd_functions=(_direnv_hook $chpwd_functions)
 fi
 `
 


### PR DESCRIPTION
* Semicolon not needed at end of command.
* `[@]` not needed if variable is not within `""`. Anyway, the quotes would only serve to expand empty-string entries in the array, which should not exist here.
* Simplify test for occurence of `_direnv_hook` in array. This syntax also works with what was previously reported in #803:

      $ set -euo pipefail
      $ typeset -ag precmd_functions
      $ print $precmd_functions

      $ print ${precmd_functions[(I)_direnv_hook]}
      0
      $ print "${precmd_functions[(r)_direnv_hook]+1}"

      $ print ${precmd_functions[(r)_direnv_hook]}
      zsh: precmd_functions[(r)_direnv_hook]: parameter not set
