### PR TITLE
Fix incorrect escape sequences during Loads under git-bash

### DIFF
--- a/internal/cmd/rc.go
+++ b/internal/cmd/rc.go
@@ -183,12 +183,16 @@ func (rc *RC) Load(previousEnv Env) (newEnv Env, err error) {
 		prelude = "set -euo pipefail && "
 	}
 
+	// Non-Windows platforms will already use slashes. However, on Windows
+	// backslashes are used by default which can result in unexpected escapes
+	// like \b or \r in paths. Force slash usage to avoid issues on Windows.
+	slashSeparatedPath := filepath.ToSlash(rc.Path())
 	arg := fmt.Sprintf(
 		`%seval "$("%s" stdlib)" && __main__ %s %s`,
 		prelude,
 		direnv,
 		fn,
-		BashEscape(rc.Path()),
+		BashEscape(slashSeparatedPath),
 	)
 
 	// G204: Subprocess launched with function call as argument or cmd arguments

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -285,6 +285,13 @@ test_start '$test'
   [[ $FOO = bar ]]
 test_stop
 
+# Make sure that directories with names that can end up creating paths like
+# \b or \r are not broken (Windows specific issue).
+test_start 'special-characters/backspace/return'
+  direnv_eval
+  test_eq "${HI}" "there"
+test_stop
+
 # Context: foo/bar is a symlink to ../baz. foo/ contains and .envrc file
 # BUG: foo/bar is resolved in the .envrc execution context and so can't find
 #      the .envrc file.

--- a/test/scenarios/special-characters/backspace/return/.envrc
+++ b/test/scenarios/special-characters/backspace/return/.envrc
@@ -1,0 +1,1 @@
+export HI=there


### PR DESCRIPTION
https://github.com/direnv/direnv/pull/975 had the unintended consequence of causing the `RC::Load` call to sometimes fail when running under git-bash (and some others Windows specific configs).

The `RC::Load` -> `cmd.Output()` calls end up interpreting characters like \b or \t as escape sequences, which is problematic for paths like 'myProject\buckets\test'.

This patch addresses this by forcing the use of `/` as a separator, even on Windows. This works fine in my testing in git-bash. This shouldn't impact systems where `/` is already in use.

This also adds a test case that covers the behaviour being adjusted. In order to run the bash tests on Windows, I had to disable a number that appear to not play nice -- but after hacking those out I was able to verify the new test case.

Fixes:
- https://github.com/direnv/direnv/issues/1020
- https://github.com/direnv/direnv/issues/1079