### PR TITLE
Fix golangci-lint issues

### DIFF
--- a/internal/cmd/cmd_allow.go
+++ b/internal/cmd/cmd_allow.go
@@ -23,7 +23,7 @@ better to keep that folder for user-editable configuration so the data is
 being moved to XDG_DATA_HOME.
 `
 
-func cmdAllowAction(env Env, args []string, config *Config) (err error) {
+func cmdAllowAction(_ Env, args []string, config *Config) (err error) {
 	var rcPath string
 	if len(args) > 1 {
 		if rcPath, err = filepath.Abs(args[1]); err != nil {

--- a/internal/cmd/cmd_deny.go
+++ b/internal/cmd/cmd_deny.go
@@ -15,7 +15,7 @@ var CmdDeny = &Cmd{
 	Action:  actionWithConfig(cmdDenyAction),
 }
 
-func cmdDenyAction(env Env, args []string, config *Config) (err error) {
+func cmdDenyAction(_ Env, args []string, config *Config) (err error) {
 	var rcPath string
 
 	if len(args) > 1 {

--- a/internal/cmd/cmd_dotenv.go
+++ b/internal/cmd/cmd_dotenv.go
@@ -19,7 +19,7 @@ var CmdDotEnv = &Cmd{
 	Action:  actionSimple(cmdDotEnvAction),
 }
 
-func cmdDotEnvAction(env Env, args []string) (err error) {
+func cmdDotEnvAction(_ Env, args []string) (err error) {
 	var shell Shell
 	var newenv Env
 	var target string

--- a/internal/cmd/cmd_fetchurl.go
+++ b/internal/cmd/cmd_fetchurl.go
@@ -20,7 +20,7 @@ var CmdFetchURL = &Cmd{
 	Action: actionWithConfig(cmdFetchURL),
 }
 
-func cmdFetchURL(env Env, args []string, config *Config) (err error) {
+func cmdFetchURL(_ Env, args []string, config *Config) (err error) {
 	if len(args) < 2 {
 		return fmt.Errorf("missing URL argument")
 	}

--- a/internal/cmd/cmd_hook.go
+++ b/internal/cmd/cmd_hook.go
@@ -21,7 +21,7 @@ var CmdHook = &Cmd{
 	Action: actionSimple(cmdHookAction),
 }
 
-func cmdHookAction(env Env, args []string) (err error) {
+func cmdHookAction(_ Env, args []string) (err error) {
 	var target string
 
 	if len(args) > 1 {

--- a/internal/cmd/cmd_prune.go
+++ b/internal/cmd/cmd_prune.go
@@ -13,7 +13,7 @@ var CmdPrune = &Cmd{
 	Action: actionWithConfig(cmdPruneAction),
 }
 
-func cmdPruneAction(env Env, args []string, config *Config) (err error) {
+func cmdPruneAction(_ Env, _ []string, config *Config) (err error) {
 	var dir *os.File
 	var fi os.FileInfo
 	var dirList []string

--- a/internal/cmd/cmd_show_dump.go
+++ b/internal/cmd/cmd_show_dump.go
@@ -17,7 +17,7 @@ var CmdShowDump = &Cmd{
 	Action:  actionSimple(cmdShowDumpAction),
 }
 
-func cmdShowDumpAction(env Env, args []string) (err error) {
+func cmdShowDumpAction(_ Env, args []string) (err error) {
 	if len(args) < 2 {
 		return fmt.Errorf("missing DUMP argument")
 	}

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -8,7 +8,7 @@ import (
 
 type actionSimple func(env Env, args []string) error
 
-func (fn actionSimple) Call(env Env, args []string, config *Config) error {
+func (fn actionSimple) Call(env Env, args []string, _ *Config) error {
 	return fn(env, args)
 }
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -57,8 +57,8 @@ type tomlGlobal struct {
 }
 
 type tomlWhitelist struct {
-	Prefix []string
-	Exact  []string
+	Prefix []string `toml:"prefix"`
+	Exact  []string `toml:"exact"`
 }
 
 // Expand a path string prefixed with ~/ to the current user's home directory.

--- a/internal/cmd/file_times.go
+++ b/internal/cmd/file_times.go
@@ -11,9 +11,9 @@ import (
 
 // FileTime represents a single recorded file status
 type FileTime struct {
-	Path    string
-	Modtime int64
-	Exists  bool
+	Path    string `json:"path"`
+	Modtime int64  `json:"modtime"`
+	Exists  bool   `json:"exists"`
 }
 
 // FileTimes represent a record of all the known files and times


### PR DESCRIPTION
Fixes issues preventing golangci-lint from passing. Following this `golangci-lint run` and `make test` (which calls into golangci-lint) should not fail at the lint step.

- Change unused argument names to `_`.
- Add toml and json tags to a couple of structs that are serialized as toml and json respectively.