### PR TITLE
stdlib: use_flake: don't keep old generations around

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1268,6 +1268,7 @@ use_flake() {
   watch_file flake.lock
   mkdir -p "$(direnv_layout_dir)"
   eval "$(nix print-dev-env --profile "$(direnv_layout_dir)/flake-profile" "$@")"
+  nix profile wipe-history --profile "$(direnv_layout_dir)/flake-profile"
 }
 
 # Usage: use_guix [...]


### PR DESCRIPTION
Note: Unless there's consensus that this is a good idea, let's talk about it. I've just noticed these things eating up my disk space without manual intervention, and it seemed annoying. And I thought a PR is a nicer discussion base than a feature request.

(I also haven't actually run the code yet :scream:  I'll get to that in the next days)

---

This is a pretty significant change for people who care about this, but I'd argue that this is very rarely the case.

The two reasons I can see why one would like to keep an old generation are
1. Enable rollbacks
2. Prevent garbage collection

Given that use_flake is always used with a flake.nix file and most probably in a version controlled project, reverting flake.nix seems like an easier way to roll back than fiddling with generations (which would be overridden by direnv pretty soon anyways)

Garbage collection is a better reason imo, but still, actually going back to old versions is probably relatively rare, and stuff isn't collected before nix-collect-garbage is ran anyways.