### PR TITLE
Skip some tests for IBM Z mainframe's z/OS operating system

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -103,6 +103,15 @@ tests = \
 				test-tcsh \
 				test-zsh
 
+# Skip few checks for IBM Z mainframe's z/OS aka OS/390
+ifeq ($(shell uname), OS/390)
+	tests = \
+		test-stdlib \
+		test-go \
+		test-go-fmt \
+		test-bash
+endif
+
 .PHONY: $(tests)
 test: build $(tests)
 	@echo


### PR DESCRIPTION
Firstly, thank you for this excellent tool!

I've built this from source successfully.
Skipping some tests (fish, zsh, etc. don't exist for IBM Z) in order to get `make test` to run cleanly for this platform.