### PR TITLE
Add Windows installation with winget

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,6 +20,7 @@ direnv is packaged for a variety of systems:
 * [MacPorts](https://ports.macports.org/port/direnv/)
 * [Ubuntu](https://packages.ubuntu.com/search?keywords=direnv&searchon=names&suite=all&section=all)
 * [GNU Guix](https://www.gnu.org/software/guix/)
+* [Windows](https://learn.microsoft.com/en-us/windows/package-manager/winget/)
 
 See also:
 


### PR DESCRIPTION
direnv [has been packaged for winget](https://github.com/microsoft/winget-pkgs/pull/106059) which allows to install it from binariees on Windows with `winget install direnv.direnv`:

![image](https://user-images.githubusercontent.com/80741/236923065-409142d6-f5a4-4324-9230-5177eb5ddcfa.png)

I've successfully used `direnv` in Git Bash on Windows 11:

![image](https://user-images.githubusercontent.com/80741/236923178-5dacbf8f-f1ec-441a-b8b8-88158a5fa245.png)

UPDATE: There are quirks on Windows. It works, unless initials of path names together with Windows path separator make one of C-escape codes e.g. `\t` or `\a`

![image](https://user-images.githubusercontent.com/80741/237023973-86dd6fa3-6385-415a-a6fb-49bf33cfc77f.png)
