### PR TITLE
fix: source-env was printing incorrect path

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -349,7 +349,7 @@ source_env() {
   pushd "$(pwd 2>/dev/null)" >/dev/null || return 1
   pushd "$rcpath_dir" >/dev/null || return 1
   if [[ -f ./$rcpath_base ]]; then
-    log_status "loading $(user_rel_path "$(expand_path "$rcpath")")"
+    log_status "loading $(user_rel_path "$(expand_path "$rcpath_base")")"
     # shellcheck disable=SC1090
     . "./$rcpath_base"
   else

--- a/test/stdlib.bash
+++ b/test/stdlib.bash
@@ -197,6 +197,28 @@ test_name source_env_if_exists
   [[ "${output#*'loading ~/existing_file'}" != "$output" ]]
 )
 
+test_name inherit-parent
+(
+  load_stdlib
+
+  workdir=$(mktemp -d)
+  trap 'rm -rf "$workdir"' EXIT
+
+  cd "$workdir"
+  echo 'export SUCCESS=true' > "$workdir/.envrc"
+  mkdir -p "$workdir/sub/dir"
+  cd "$workdir/sub/dir"
+
+  # inherit grandparent envrc
+  source_env ../..
+  [[ $SUCCESS = true ]]
+
+  # Expect correct path being logged
+  export HOME=$workdir
+  output="$(source_env ../.. 2>&1 > /dev/null)"
+  assert_eq "$output" "direnv: loading ~/.envrc"
+)
+
 test_name env_vars_required
 (
   load_stdlib


### PR DESCRIPTION
Previously, the path printed was a non-existing file which was two parent directories removed from the actual file.