### PR TITLE
fix(test): test-in-envrc was a noop

### DIFF
--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -160,12 +160,14 @@ test_start "empty-var-unset"
 test_stop
 
 test_start "in-envrc"
+  # demonstrate a conditional on $DIRENV_IN_ENVRC
   direnv_eval
-  set +e
-  ./test-in-envrc
-  es=$?
-  set -e
-  test_eq "$es" "1"
+  test_eq "$?" "0"
+  test_eq "$FROM_ENVRC" true
+  unset FROM_ENVRC
+  . ./.envrc || exit_status=$?
+  test_eq "$exit_status" 1
+  test_eq "$FROM_ENVRC" ""
 test_stop
 
 test_start "missing-file-source-env"

--- a/test/scenarios/in-envrc/.envrc
+++ b/test/scenarios/in-envrc/.envrc
@@ -1,0 +1,2 @@
+#!/bin/sh
+test -n "$DIRENV_IN_ENVRC" && export FROM_ENVRC=true

--- a/test/scenarios/in-envrc/test-in-envrc
+++ b/test/scenarios/in-envrc/test-in-envrc
@@ -1,2 +1,0 @@
-#!/bin/sh
-test -n "$DIRENV_IN_ENVRC" && echo "in envrc"


### PR DESCRIPTION
Previously, the `test -n "$DIRENV_IN_ENVRC"` was not being run by direnv, since it did not appear in `.envrc`. This wasn't noticed because there was no assertion of the `echo "in envrc"`.

Now, an environment value is exported and checked, which prevents this kind of mistake in future.