### PR TITLE
Print correct path in source_env log message

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -349,7 +349,7 @@ source_env() {
   pushd "$(pwd 2>/dev/null)" >/dev/null || return 1
   pushd "$rcpath_dir" >/dev/null || return 1
   if [[ -f ./$rcpath_base ]]; then
-    log_status "loading $(user_rel_path "$(expand_path "$rcpath")")"
+    log_status "loading $(user_rel_path "$(expand_path "$rcpath_base")")"
     # shellcheck disable=SC1090
     . "./$rcpath_base"
   else


### PR DESCRIPTION
Without this change, when source_env loads a file from subdirectory the subdirectory is duplicated in the printed path. For example, if `~/tmp/.envrc` contains:

    source_env subdir

direnv prints:

    direnv: loading ~/tmp/subdir/subdir/.envrc

Fixes #1143