### PR TITLE
stdlib: create CACHEDIR.TAG inside .direnv

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -24,6 +24,7 @@ stdenv'.mkDerivation  {
 
     # Test dependencies
     golangci-lint
+    python3
     ruby
     shellcheck
     shfmt

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -749,6 +749,14 @@ layout() {
   local funcname="layout_$1"
   shift
   "$funcname" "$@"
+  local layout_dir
+  layout_dir=$(direnv_layout_dir)
+  if [[ -d "$layout_dir" && ! -f "$layout_dir/CACHEDIR.TAG" ]]; then
+    echo 'Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by direnv.
+# For information about cache directory tags, see:
+#	http://www.brynosaurus.com/cachedir/' > "$layout_dir/CACHEDIR.TAG"
+  fi
 }
 
 # Usage: layout go

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -257,6 +257,11 @@ if has python; then
       echo "FAILED: VIRTUAL_ENV/bin not added to PATH"
       exit 1
     fi
+
+    if [[ ! -f .direnv/CACHEDIR.TAG ]]; then
+      echo "the layout dir should contain that file to filter that folder out of backups"
+      exit 1
+    fi
   test_stop
 
   test_start "python-custom-virtual-env"


### PR DESCRIPTION
This allows backup software to skip this directory for backups