### PR TITLE
add support for armv7l platform in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,9 @@ set -euo pipefail
     i686 | i386)
       machine=386
       ;;
+    armv7l)
+      machine=arm
+      ;;
     aarch64 | arm64)
       machine=arm64
       ;;
@@ -81,7 +84,7 @@ set -euo pipefail
     curl -fL "https://api.github.com/repos/direnv/direnv/releases/$release" \
     | grep browser_download_url \
     | cut -d '"' -f 4 \
-    | grep "direnv.$kernel.$machine"
+    | grep "direnv.$kernel.$machine\$"
   )
   echo "download_url=$download_url"
 


### PR DESCRIPTION
Hello,
the machine=arm is known under several uname -m's.
I have added 2 fixes:
1) armv7l -> arm
2) in the part where the download url is found, both arm64 and arm is found for machine=arm so I added an end of line anchor to the grep.

2) can have unforeseen consequences if other machines expect a loose match instead of a rigid match.