### PR TITLE
stdlib: add use_flakepath function

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -454,6 +454,29 @@ Load environment variables from \fB\fCguix shell\fR\&.
 .PP
 Any arguments given will be passed to guix shell. For example, \fB\fCuse guix hello\fR would setup an environment including the hello package. To create an environment with the hello dependencies, the \fB\fC--development\fR flag is used \fB\fCuse guix --development hello\fR\&. Other options include \fB\fC--file\fR which allows loading an environment from a file.
 
+.SS \fB\fCuse flakepath [<installable>]\fR
+.PP
+Load the PATH of a derivation similar to \fB\fCnix develop\fR\& (without switching shells).
+
+.PP
+Depends on jq
+
+.PP
+By default it will load the current folder flake.nix devShell attribute. Or
+pass an "installable" like "nixpkgs#hello" to load all the build dependencies
+of the hello package from the latest nixpkgs.
+
+.PP
+Note that the flakes feature is hidden behind an experimental flag, which you
+will have to enable on your own. Flakes is not considered stable yet.
+
+.SS \fB\fCuse guix [...]\fR
+.PP
+Load environment variables from \fB\fCguix shell\fR\&.
+
+.PP
+Any arguments given will be passed to guix shell. For example, \fB\fCuse guix hello\fR would setup an environment including the hello package. To create an environment with the hello dependencies, the \fB\fC--development\fR flag is used \fB\fCuse guix --development hello\fR\&. Other options include \fB\fC--file\fR which allows loading an environment from a file.
+
 .PP
 See https://guix.gnu.org/en/manual/en/guix.html#Invoking-guix-shell
 

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -92,7 +92,7 @@ Example:
 
 ### `env_vars_required <varname> [<varname> ...]`
 
-Logs error for every variable not present in the environment or having an empty value.  
+Logs error for every variable not present in the environment or having an empty value.
 Typically this is used in combination with source_env and source_env_if_exists.
 
 Example:
@@ -318,6 +318,19 @@ See http://nixos.org/nix/manual/#sec-nix-shell
 ### `use flake [<installable>]`
 
 Load the build environment of a derivation similar to `nix develop`.
+
+By default it will load the current folder flake.nix devShell attribute. Or
+pass an "installable" like "nixpkgs#hello" to load all the build dependencies
+of the hello package from the latest nixpkgs.
+
+Note that the flakes feature is hidden behind an experimental flag, which you
+will have to enable on your own. Flakes is not considered stable yet.
+
+### `use flakepath [<installable>]`
+
+Load the PATH of a derivation similar to `nix develop` (without switching shells).
+
+Depends on jq
 
 By default it will load the current folder flake.nix devShell attribute. Or
 pass an "installable" like "nixpkgs#hello" to load all the build dependencies

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1290,13 +1290,7 @@ use_flakepath() {
   watch_file flake.nix
   watch_file flake.lock
 
-  OLDIFS=$IFS
-  IFS=":"
-
-  for path in $(nix print-dev-env "$@" --json | jq ".variables.PATH.value" -r); do
-    PATH_add $path
-  done
-  export IFS=$OLDIFS
+  PATH_add "$(nix develop -c sh -c 'echo $PATH')"`
 }
 
 # Usage: use_guix [...]

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -377,7 +377,7 @@ source_env_if_exists() {
 
 # Usage: env_vars_required <varname> [<varname> ...]
 #
-# Logs error for every variable not present in the environment or having an empty value.  
+# Logs error for every variable not present in the environment or having an empty value.
 # Typically this is used in combination with source_env and source_env_if_exists.
 #
 # Example:
@@ -1276,6 +1276,27 @@ use_flake() {
   watch_file flake.lock
   mkdir -p "$(direnv_layout_dir)"
   eval "$(nix print-dev-env --profile "$(direnv_layout_dir)/flake-profile" "$@")"
+}
+
+# Usage: use_flakepath [<installable>]
+#
+# Load PATH from your flake, similiar to `nix develop` but without loading a new shell.
+#
+# Behaves like use_flake except that it only modifies your PATH
+#
+# Note that the flakes feature is hidden behind an experimental flag, which
+# you will have to enable on your own. Flakes is not considered stable yet.
+use_flakepath() {
+  watch_file flake.nix
+  watch_file flake.lock
+
+  OLDIFS=$IFS
+  IFS=":"
+
+  for path in $(nix print-dev-env "$@" --json | jq ".variables.PATH.value" -r); do
+    PATH_add $path
+  done
+  export IFS=$OLDIFS
 }
 
 # Usage: use_guix [...]


### PR DESCRIPTION
Function is very similiar to use_flake, except it parses the PATH variable of the nix environment and appends it.

Users of other shells that don't want to use "shellHook" to exec back into their prefered shells, and only need PATH modified might appreciate this.

In contradiction to use_flake we don't create a profile, if you use nix-collect-garbage while inside a shell like this, you'll lose your PATH entries.

@zimbatm I'd like your input, since you're the author of use_flake 😄 