### PR TITLE
Remove redundant nil check in `CommandsDispatch`

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -109,11 +109,9 @@ func CommandsDispatch(env Env, args []string) error {
 			command = cmd
 			break
 		}
-		if cmd.Aliases != nil {
-			for _, alias := range cmd.Aliases {
-				if alias == commandName {
-					command = cmd
-				}
+		for _, alias := range cmd.Aliases {
+			if alias == commandName {
+				command = cmd
 			}
 		}
 	}


### PR DESCRIPTION
From the Go specification:

> "1. For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/ZkGmict4Iqj