### PR TITLE
add a Nushell section to `hook.md`

### DIFF
--- a/docs/hook.md
+++ b/docs/hook.md
@@ -64,7 +64,7 @@ use direnv
 
 ## Nushell
 
-add the following hook to your `$env.config.hooks.env_change.PWD` list in `config.nu`:
+Add the following hook to your `$env.config.hooks.env_change.PWD` list in `config.nu`:
 ```nushell
 { ||
     if (which direnv | is-empty) {

--- a/docs/hook.md
+++ b/docs/hook.md
@@ -61,3 +61,20 @@ and add the following line to your `~/.elvish/rc.elv` file:
 ```
 use direnv
 ```
+
+## Nushell
+
+add the following hook to your `$env.config.hooks.env_change.PWD` list in `config.nu`:
+```nushell
+{ ||
+    if (which direnv | is-empty) {
+        return
+    }
+
+    direnv export json | from json | default {} | load-env
+}
+```
+
+> **Note**
+> you can follow the [`nu_scripts` of Nushell](https://github.com/nushell/nu_scripts/blob/main/hooks/direnv/config.nu)
+> for the always up-to-date version of the hook above


### PR DESCRIPTION
i just discovered `direnv` and i thought i could give a spin at adding some instructions on how to add some Nushell support :yum: 

> **Important**
> see the [new `hook.md`](https://github.com/amtoine/direnv/blob/add-hook-support-for-nushell/docs/hook.md#nushell) :pray: 

in this PR, i've
- copied the structure of the other shells in `hook.md` and
- added a hook that
  - runs only when `direnv` is installed
  - uses `direnv export json` and default to an empty environment record
  - loads the environment
- a link to the [hook in the `nu_scripts`](https://github.com/nushell/nu_scripts/blob/main/hooks/direnv/config.nu) to stay up-to-date 

hope you will like the change :innocent: 
cheers :partying_face: 

> **Note**
> the hook in the `hook.md` is not the same as in the `nu_scripts`, i've just rewritten it and will submit a PR on our side to update it :wink: 
> 
> :point_right: see [nushell/nu_scripts#628](https://github.com/nushell/nu_scripts/pull/628)