### PR TITLE
stdlib: update layout_python to resolve deprecation warning

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -821,7 +821,7 @@ layout_python() {
   else
     local python_version ve
     # shellcheck disable=SC2046
-    read -r python_version ve <<<$($python -c "import pkgutil as u, platform as p;ve='venv' if u.find_loader('venv') else ('virtualenv' if u.find_loader('virtualenv') else '');print('.'.join(p.python_version_tuple()[:2])+' '+ve)")
+    read -r python_version ve <<<$($python -c "import importlib.util as u, platform as p;ve='venv' if u.find_spec('venv') else ('virtualenv' if u.find_spec('virtualenv') else '');print('.'.join(p.python_version_tuple()[:2])+' '+ve)")
     if [[ -z $python_version ]]; then
       log_error "Could not find python's version"
       return 1


### PR DESCRIPTION
Since python 3.12 was released, `layout python` produces the following warning: `<string>:1: DeprecationWarning: 'pkgutil.find_loader' is deprecated and slated for removal in Python 3.14; use importlib.util.find_spec() instead`. This commit resolves the warning by using the suggested alternative.

Issues: This will break `layout python2` and `layout python3` for versions before 3.4.