### PR TITLE
feat: alias `direnv disallow` to deny

### DIFF
--- a/internal/cmd/cmd_deny.go
+++ b/internal/cmd/cmd_deny.go
@@ -11,7 +11,7 @@ var CmdDeny = &Cmd{
 	Name:    "block",
 	Desc:    "Revokes the authorization of a given .envrc or .env file.",
 	Args:    []string{"[PATH_TO_RC]"},
-	Aliases: []string{"deny", "revoke"},
+	Aliases: []string{"deny", "disallow", "revoke"},
 	Action:  actionWithConfig(cmdDenyAction),
 }
 

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -278,10 +278,12 @@ fi
 test_start "aliases"
   direnv deny
   # check that allow/deny aliases work
-  direnv permit && direnv_eval && test -n "${HELLO}"
-  direnv block  && direnv_eval && test -z "${HELLO}"
-  direnv grant  && direnv_eval && test -n "${HELLO}"
-  direnv revoke && direnv_eval && test -z "${HELLO}"
+  direnv permit   && direnv_eval && test -n "${HELLO}"
+  direnv block    && direnv_eval && test -z "${HELLO}"
+  direnv grant    && direnv_eval && test -n "${HELLO}"
+  direnv revoke   && direnv_eval && test -z "${HELLO}"
+  direnv grant    && direnv_eval && test -n "${HELLO}"
+  direnv disallow && direnv_eval && test -z "${HELLO}"
 test_stop
 
 # shellcheck disable=SC2016


### PR DESCRIPTION
I don't often have to turn direnv off, so I haven't been able to learn that it's `direnv deny` or `direnv revoke`. Instead I always find myself trying to run `direnv disallow` since it's the direct inverse of `direnv allow` in my head. 