### PR TITLE
fix: support Bash 5.1 array PROMPT_COMMAND

### DIFF
--- a/internal/cmd/shell_bash.go
+++ b/internal/cmd/shell_bash.go
@@ -15,8 +15,12 @@ _direnv_hook() {
   trap - SIGINT;
   return $previous_exit_status;
 };
-if ! [[ "${PROMPT_COMMAND:-}" =~ _direnv_hook ]]; then
-  PROMPT_COMMAND="_direnv_hook${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+if ! [[ "${PROMPT_COMMAND[*]:-}" =~ _direnv_hook ]]; then
+  if [[ "$(declare -p PROMPT_COMMAND 2>&1)" == "declare -a"* ]]; then
+    PROMPT_COMMAND=(_direnv_hook "${PROMPT_COMMAND[@]}")
+  else
+    PROMPT_COMMAND="_direnv_hook${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+  fi
 fi
 `
 


### PR DESCRIPTION
Since Bash 5.1, the PROMPT_COMMAND variable can be an array.

Fixes #1199