### PR TITLE
Update stdlib.sh to avoid deprecation warning

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -821,7 +821,7 @@ layout_python() {
   else
     local python_version ve
     # shellcheck disable=SC2046
-    read -r python_version ve <<<$($python -c "import pkgutil as u, platform as p;ve='venv' if u.find_loader('venv') else ('virtualenv' if u.find_loader('virtualenv') else '');print('.'.join(p.python_version_tuple()[:2])+' '+ve)")
+    read -r python_version ve <<<$($python -c "import importlib.util as u, platform as p;ve='venv' if u.find_spec('venv') else ('virtualenv' if u.find_spec('virtualenv') else '');print('.'.join(p.python_version_tuple()[:2])+' '+ve)")
     if [[ -z $python_version ]]; then
       log_error "Could not find python's version"
       return 1


### PR DESCRIPTION
Before this, layout python or layout pyenv would always output the following:
`DeprecationWarning: 'pkgutil.find_loader' is deprecated and slated for removal in Python 3.14; use importlib.util.find_spec() instead`