### PR TITLE
Added `export` function in `direnv help`

### DIFF
--- a/internal/cmd/cmd_export.go
+++ b/internal/cmd/cmd_export.go
@@ -7,12 +7,23 @@ import (
 	"strings"
 )
 
+func supportedShellFormattedString() string {
+	res := "["
+	for k := range supportedShellList {
+		res += k + ", "
+	}
+	res = strings.TrimSuffix(res, ", ")
+	res += "]"
+	return res
+}
+
 // CmdExport is `direnv export $0`
 var CmdExport = &Cmd{
-	Name:    "export",
-	Desc:    "loads an .envrc or .env and prints the diff in terms of exports",
+	Name: "export",
+	Desc: `Loads an .envrc or .env and prints the diff in terms of exports.
+  Supported SHELL values are: ` + supportedShellFormattedString(),
 	Args:    []string{"SHELL"},
-	Private: true,
+	Private: false,
 	Action:  cmdWithWarnTimeout(actionWithConfig(exportCommand)),
 }
 

--- a/internal/cmd/cmd_help.go
+++ b/internal/cmd/cmd_help.go
@@ -8,7 +8,7 @@ import (
 // CmdHelp is `direnv help`
 var CmdHelp = &Cmd{
 	Name:    "help",
-	Desc:    "shows this help",
+	Desc:    "Shows this help",
 	Args:    []string{"[SHOW_PRIVATE]"},
 	Aliases: []string{"--help"},
 	Action: actionSimple(func(env Env, args []string) (err error) {

--- a/internal/cmd/cmd_prune.go
+++ b/internal/cmd/cmd_prune.go
@@ -9,7 +9,7 @@ import (
 // CmdPrune is `direnv prune`
 var CmdPrune = &Cmd{
 	Name:   "prune",
-	Desc:   "removes old allowed files",
+	Desc:   "Removes old allowed files",
 	Action: actionWithConfig(cmdPruneAction),
 }
 

--- a/internal/cmd/cmd_reload.go
+++ b/internal/cmd/cmd_reload.go
@@ -7,7 +7,7 @@ import (
 // CmdReload is `direnv reload`
 var CmdReload = &Cmd{
 	Name: "reload",
-	Desc: "triggers an env reload",
+	Desc: "Triggers an env reload",
 	Action: actionWithConfig(func(env Env, args []string, config *Config) error {
 		foundRC, err := config.FindRC()
 		if err != nil {

--- a/internal/cmd/cmd_status.go
+++ b/internal/cmd/cmd_status.go
@@ -9,7 +9,7 @@ import (
 // CmdStatus is `direnv status`
 var CmdStatus = &Cmd{
 	Name: "status",
-	Desc: "prints some debug status information",
+	Desc: "Prints some debug status information",
 	Args: []string{"[--json]"},
 	Action: actionWithConfig(func(env Env, args []string, config *Config) error {
 		if len(args) > 1 && (args[1] == "-json" || args[1] == "--json") {

--- a/internal/cmd/shell.go
+++ b/internal/cmd/shell.go
@@ -31,6 +31,20 @@ func (e ShellExport) Remove(key string) {
 	e[key] = nil
 }
 
+var supportedShellList = map[string]Shell{
+	"bash":    Bash,
+	"elvish":  Elvish,
+	"fish":    Fish,
+	"gha":     GitHubActions,
+	"gzenv":   GzEnv,
+	"json":    JSON,
+	"tcsh":    Tcsh,
+	"vim":     Vim,
+	"zsh":     Zsh,
+	"pwsh":    Pwsh,
+	"systemd": Systemd,
+}
+
 // DetectShell returns a Shell instance from the given target.
 //
 // target is usually $0 and can also be prefixed by `-`
@@ -41,29 +55,9 @@ func DetectShell(target string) Shell {
 		target = target[1:]
 	}
 
-	switch target {
-	case "bash":
-		return Bash
-	case "elvish":
-		return Elvish
-	case "fish":
-		return Fish
-	case "gha":
-		return GitHubActions
-	case "gzenv":
-		return GzEnv
-	case "json":
-		return JSON
-	case "tcsh":
-		return Tcsh
-	case "vim":
-		return Vim
-	case "zsh":
-		return Zsh
-	case "pwsh":
-		return Pwsh
-	case "systemd":
-		return Systemd
+	detechedShell, isValid := supportedShellList[target]
+	if isValid {
+		return detechedShell
 	}
 
 	return nil


### PR DESCRIPTION
This PR comes from https://github.com/direnv/direnv/pull/1226#issuecomment-1891682072

Moving away from `direnv export` as a private function means we should document it in `direnv help`.