### PR TITLE
feat: hide env diff

### DIFF
--- a/internal/cmd/cmd_export.go
+++ b/internal/cmd/cmd_export.go
@@ -106,7 +106,9 @@ func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 
 	diffString := currentEnv.Diff(newEnv).ToShell(shell)
 	logDebug("env diff %s", diffString)
-	fmt.Print(diffString)
+	if !config.HideEnvDiff {
+		fmt.Print(diffString)
+	}
 	return
 }
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	BashPath        string
 	RCFile          string
 	TomlPath        string
+	HideEnvDiff     bool
 	DisableStdin    bool
 	StrictEnv       bool
 	LoadDotenv      bool

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -63,6 +63,11 @@ Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 This feature is disabled if the duration is lower or equal to zero.
 Will be overwritten if the environment variable `DIRENV_WARN_TIMEOUT` is set to any of the above values.
 
+### `hide_env_diff`
+
+Set to `true` to hide the diff of the environment variables when loading the
+`.envrc`. Defaults to `false`.
+
 ## [whitelist]
 
 Specifying whitelist directives marks specific directory hierarchies or specific directories as "trusted" -- direnv will evaluate any matching .envrc files regardless of whether they have been specifically allowed. **This feature should be used with great care**, as anyone with the ability to write files to that directory (including collaborators on VCS repositories) will be able to execute arbitrary code on your computer.


### PR DESCRIPTION
Some users don't want to see what environment variables have changed in
the shell.

Fixes part of #68
