### PR TITLE
direnv edit: editor when EDITOR not found, closes #1246

### DIFF
--- a/internal/cmd/cmd_edit.go
+++ b/internal/cmd/cmd_edit.go
@@ -86,6 +86,7 @@ func cmdEditAction(env Env, args []string, config *Config) (err error) {
 
 // Editors contains a list of known editors and how to start them.
 var Editors = [][]string{
+	{"editor"},
 	{"subl", "-w"},
 	{"mate", "-w"},
 	{"open", "-t", "-W"}, // Opens with the default text editor on mac


### PR DESCRIPTION
given EDITOR not set by the user, use editor set by the system administrator.