### PR TITLE
Powershell: Delimit envrionment variable names when setting

### DIFF
--- a/internal/cmd/shell_pwsh.go
+++ b/internal/cmd/shell_pwsh.go
@@ -58,7 +58,7 @@ func (sh pwsh) export(key, value string) string {
 	if !regexp.MustCompile(`'.*'`).MatchString(value) {
 		value = fmt.Sprintf("'%s'", value)
 	}
-	return fmt.Sprintf("$env:%s=%s;", sh.escape(key), value)
+	return fmt.Sprintf("${env:%s}=%s;", sh.escape(key), value)
 }
 
 func (sh pwsh) unset(key string) string {


### PR DESCRIPTION
This is the simplest fix for the problem outlined in #1254: It just uses a brace pattern to delimit what the environment variable name key should be regardless of how `key` needs escaped. This lets it determine that the escape quotes are _only_ for key instantiation. 

With this patch `cd`ing in and out of my project directory works exactly like I'd expect and has no errors.

There might be another fix, like stripping unnecessary quoting, but this seems more robust and like it will work in more cases. I don't know how to write a test for this specific issue though since I'm unsure of how to minimize a Nix flake's output into `direnv`'s test case definitions. If regression tests are wanted, help is appreciated please :)

cc @bamsammich as the original PowerShell support implementer 

Closes https://github.com/direnv/direnv/issues/1254