### PR TITLE
add NuShell into list of supported shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ used to build solutions similar to rbenv, pyenv and phpenv.
 ### Prerequisites
 
 * Unix-like operating system (macOS, Linux, ...)
-* A supported shell (bash, zsh, tcsh, fish, elvish, powershell, murex)
+* A supported shell (bash, zsh, tcsh, fish, elvish, powershell, murex, nushell)
 
 ### Basic Installation
 


### PR DESCRIPTION
Hey!
Just a small update to README.md
On first look, I think that direnv isn't support NuShell :(
This patch will exclude such missunderstanding