### PR TITLE
stdlib: export GOBIN for layout_go

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -788,7 +788,7 @@ layout() {
 # Usage: layout go
 #
 # Adds "$(direnv_layout_dir)/go" to the GOPATH environment variable.
-# Furthermore "$(direnv_layout_dir/go/bin" is set as the value for the GOBIN environment variable and added to the PATH environment variable.
+# Furthermore "$(direnv_layout_dir)/go/bin" is set as the value for the GOBIN environment variable and added to the PATH environment variable.
 layout_go() {
   path_add GOPATH "$(direnv_layout_dir)/go"
 

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -788,11 +788,13 @@ layout() {
 # Usage: layout go
 #
 # Adds "$(direnv_layout_dir)/go" to the GOPATH environment variable.
-# And also adds "$PWD/bin" to the PATH environment variable.
-#
+# Furthermore "$(direnv_layout_dir/go/bin" is set as the value for the GOBIN environment variable and added to the PATH environment variable.
 layout_go() {
   path_add GOPATH "$(direnv_layout_dir)/go"
-  PATH_add "$(direnv_layout_dir)/go/bin"
+
+  bindir="$(direnv_layout_dir)/go/bin"
+  PATH_add "$bindir"
+  export GOBIN="$bindir"
 }
 
 # Usage: layout node


### PR DESCRIPTION
This ensures that new binaries are installed into project-specific directories instead of the global one (if set). Since it only affects **the installation of new binaries** (using `go install`), it does not conflict with existing setups.