### PR TITLE
stdlib: enable flakes when use flake is used

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1309,8 +1309,8 @@ use_flake() {
   watch_file flake.nix
   watch_file flake.lock
   mkdir -p "$(direnv_layout_dir)"
-  eval "$(nix print-dev-env --profile "$(direnv_layout_dir)/flake-profile" "$@")"
-  nix profile wipe-history --profile "$(direnv_layout_dir)/flake-profile"
+  eval "$(nix --extra-experimental-features "nix-command flakes" print-dev-env --profile "$(direnv_layout_dir)/flake-profile" "$@")"
+  nix --extra-experimental-features "nix-command flakes" profile wipe-history --profile "$(direnv_layout_dir)/flake-profile"
 }
 
 # Usage: use_guix [...]


### PR DESCRIPTION
Tools that use flake feature should enable the necessary flags. This is best practice in the nix tooling ecosystem introduced by nixos-rebuild.