### PR TITLE
Update elvish docs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -72,7 +72,7 @@ fmt-go:
 	$(GO) fmt
 
 fmt-sh:
-	@command -v shfmt >/dev/null || (echo "Could not format stdlib.sh because shfmt is missing. Run: go get -u mvdan.cc/sh/cmd/shfmt"; false)
+	@command -v shfmt >/dev/null || (echo "Could not format stdlib.sh because shfmt is missing. Run: go install mvdan.cc/sh/cmd/shfmt@latest"; false)
 	shfmt -i 2 -w stdlib.sh
 
 ############################################################################
@@ -86,7 +86,7 @@ roffs = $(man_md:.md=)
 man: $(roffs)
 
 %.1: %.1.md
-	@command -v go-md2man >/dev/null || (echo "Could not generate man page because go-md2man is missing. Run: go get -u github.com/cpuguy83/go-md2man/v2"; false)
+	@command -v go-md2man >/dev/null || (echo "Could not generate man page because go-md2man is missing. Run: go install github.com/cpuguy83/go-md2man/v2@latest"; false)
 	go-md2man -in $< -out $@
 
 ############################################################################

--- a/docs/hook.md
+++ b/docs/hook.md
@@ -63,10 +63,11 @@ eval `direnv hook tcsh`
 Run:
 
 ```
-$> direnv hook elvish > ~/.elvish/lib/direnv.elv
+~> mkdir -p ~/.config/elvish/lib
+~> direnv hook elvish > ~/.config/elvish/lib/direnv.elv
 ```
 
-and add the following line to your `~/.elvish/rc.elv` file:
+and add the following line to your `~/.config/elvish/rc.elv` file:
 
 ```
 use direnv

--- a/man/direnv.1
+++ b/man/direnv.1
@@ -44,7 +44,6 @@ direnv: unloading
 direnv export: ~PATH
 $ echo ${FOO-nope}
 nope
-
 .EE
 
 .SH SETUP
@@ -58,7 +57,6 @@ Add the following line at the end of the \fB~/.bashrc\fR file:
 
 .EX
 eval "$(direnv hook bash)"
-
 .EE
 
 .PP
@@ -71,7 +69,6 @@ Add the following line at the end of the \fB~/.zshrc\fR file:
 
 .EX
 eval "$(direnv hook zsh)"
-
 .EE
 
 .SS FISH
@@ -80,7 +77,6 @@ Add the following line at the end of the \fB$XDG_CONFIG_HOME/fish/config.fish\fR
 
 .EX
 direnv hook fish | source
-
 .EE
 
 .PP
@@ -90,7 +86,6 @@ Fish supports 3 modes you can set with with the global environment variable \fBd
 set -g direnv_fish_mode eval_on_arrow    # trigger direnv at prompt, and on every arrow-based directory change (default)
 set -g direnv_fish_mode eval_after_arrow # trigger direnv at prompt, and only after arrow-based directory changes before executing command
 set -g direnv_fish_mode disable_arrow    # trigger direnv at prompt only, this is similar functionality to the original behavior
-
 .EE
 
 .SS TCSH
@@ -99,7 +94,6 @@ Add the following line at the end of the \fB~/.cshrc\fR file:
 
 .EX
 eval `direnv hook tcsh`
-
 .EE
 
 .SS Elvish
@@ -107,16 +101,15 @@ eval `direnv hook tcsh`
 Run:
 
 .EX
-$> direnv hook elvish > ~/.elvish/lib/direnv.elv
-
+~> mkdir -p ~/.config/elvish/lib
+~> direnv hook elvish > ~/.config/elvish/lib/direnv.elv
 .EE
 
 .PP
-and add the following line to your \fB~/.elvish/rc.elv\fR file:
+and add the following line to your \fB~/.config/elvish/rc.elv\fR file:
 
 .EX
 use direnv
-
 .EE
 
 .SS PowerShell
@@ -125,7 +118,6 @@ Add the following line to your \fB$PROFILE\fR:
 
 .EX
 Invoke-Expression "$(direnv hook pwsh)"
-
 .EE
 
 .SS Murex
@@ -134,7 +126,6 @@ Add the following line to your \fB~/.murex_profile\fR:
 
 .EX
 direnv hook murex -> source
-
 .EE
 
 .SH USAGE

--- a/man/direnv.1.md
+++ b/man/direnv.1.md
@@ -105,10 +105,11 @@ eval `direnv hook tcsh`
 Run:
 
 ```
-$> direnv hook elvish > ~/.elvish/lib/direnv.elv
+~> mkdir -p ~/.config/elvish/lib
+~> direnv hook elvish > ~/.config/elvish/lib/direnv.elv
 ```
 
-and add the following line to your `~/.elvish/rc.elv` file:
+and add the following line to your `~/.config/elvish/rc.elv` file:
 
 ```
 use direnv


### PR DESCRIPTION
The elvish install instruction use a deprecated (since 0.16) location for elvish modules.

I also needed a different command to install the command to generate the man page.