### PR TITLE
fix(tcsh): respect pre-existing precmd on hook

### DIFF
--- a/internal/cmd/shell_tcsh.go
+++ b/internal/cmd/shell_tcsh.go
@@ -11,7 +11,13 @@ type tcsh struct{}
 var Tcsh Shell = tcsh{}
 
 func (sh tcsh) Hook() (string, error) {
-	return "alias precmd 'eval `{{.SelfPath}} export tcsh`'", nil
+	commands := []string{
+		"set USER_PRECMD = \"`alias precmd`\";",
+		"set DIRENV_PRECMD = 'alias precmd 'eval `{{.SelfPath}} export tcsh`'';",
+		"alias precmd \"$DIRENV_PRECMD;$USER_PRECMD\";",
+	}
+	init := strings.Join(commands, "\n")
+	return init, nil
 }
 
 func (sh tcsh) Export(e ShellExport) (out string) {


### PR DESCRIPTION
## Short description
Fixes #1304.

Current implementation completely overrides contents of `precmd` tcsh hook. This causes issues for other utils relying on precmd:
https://github.com/starship/starship/issues/6093

## Changes
Re-written hook logic for tcsh following example of starship implementation:
https://github.com/starship/starship/blob/master/src/init/starship.tcsh