### PR TITLE
docs: Add version requirement for load_dotenv option

### DIFF
--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -50,6 +50,10 @@ If set to \fBtrue\fR, stdin is disabled (redirected to /dev/null) during the \fB
 
 .SS \fBload_dotenv\fR
 .PP
+.RS
+direnv >= 2.31.0 is required
+.RE
+.PP
 If set to \fBtrue\fR, also look for and load \fB\&.env\fR files on top of the \fB\&.envrc\fR files. If both \fB\&.envrc\fR and \fB\&.env\fR files exist, the \fB\&.envrc\fR will always be chosen first.
 
 .SS \fBstrict_env\fR

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -44,6 +44,8 @@ If set to `true`, stdin is disabled (redirected to /dev/null) during the `.envrc
 
 ### `load_dotenv`
 
+> direnv >= 2.31.0 is required
+
 If set to `true`, also look for and load `.env` files on top of the `.envrc` files. If both `.envrc` and `.env` files exist, the `.envrc` will always be chosen first.
 
 ### `strict_env`


### PR DESCRIPTION
Added version information (`direnv >= 2.31.0 is required`) for the `load_dotenv` option in the direnv documentation, addressing the confusion and concerns raised in #1100 and potentially helping with issues like #1189.

Version requirement was determined from PR #911, which introduced this feature.
