### PR TITLE
Change Windows package link to winget repository

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ direnv is packaged for a variety of systems:
 * [MacPorts](https://ports.macports.org/port/direnv/)
 * [Ubuntu](https://packages.ubuntu.com/search?keywords=direnv&searchon=names&suite=all&section=all)
 * [GNU Guix](https://packages.guix.gnu.org/search/?query=direnv)
-* [Windows](https://learn.microsoft.com/en-us/windows/package-manager/winget/)
+* [Windows](https://github.com/microsoft/winget-pkgs/tree/master/manifests/d/direnv/direnv)
 
 See also:
 


### PR DESCRIPTION
The previous link just pointed to generic "how to use winget" instructions which, IMO, is not that useful when trying to identify and install a specific package. I wanted to know the name and ID of the package so that I knew what `winget` command to use (`winget install --id direnv.direnv`). It's helpful to have a link to the package in the official docs, so that I can at least be confident that I'm installing the correct package and not a similarly-named package. This changes the link to the actual winget-pkgs repository, which lists package manifests. From that I, and hopefully other users, can derive the correct package ID. There's also winget.run and winstall.app, but the former seems very out-of-date and both are unofficial.

As a side-note, the docs still say that the prerequisites include a Unix-like OS (implying *not* Windows). Should that be changed?