### PR TITLE
optionally authenticate against github api during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -82,14 +82,15 @@ set -euo pipefail
   if [[ -n "${DIRENV_GITHUB_API_TOKEN:-}" ]]; then
     # note: this doesn't actually print the token value.
     echo "using DIRENV_GITHUB_API_TOKEN for GitHub API authentication"
-    authorization_args="-H 'Authorization: Bearer ${DIRENV_GITHUB_API_TOKEN}'"
+    authorization_args=(-H "Authorization: Bearer ${DIRENV_GITHUB_API_TOKEN}")
   else
-    authorization_args=""
+    authorization_args=()
   fi
 
   log "looking for a download URL"
   download_url=$(
-    curl -fL "https://api.github.com/repos/direnv/direnv/releases/$release" $authorization_args \
+    curl -fL "https://api.github.com/repos/direnv/direnv/releases/$release" \
+      "${authorization_args[@]}" \
     | grep browser_download_url \
     | cut -d '"' -f 4 \
     | grep "direnv.$kernel.$machine\$"

--- a/install.sh
+++ b/install.sh
@@ -79,9 +79,17 @@ set -euo pipefail
   fi
   echo "release=$release"
 
+  if [[ -n "${DIRENV_GITHUB_API_TOKEN:-}" ]]; then
+    # note: this doesn't actually print the token value.
+    echo "using DIRENV_GITHUB_API_TOKEN for GitHub API authentication"
+    authorization_args="-H 'Authorization: Bearer ${DIRENV_GITHUB_API_TOKEN}'"
+  else
+    authorization_args=""
+  fi
+
   log "looking for a download URL"
   download_url=$(
-    curl -fL "https://api.github.com/repos/direnv/direnv/releases/$release" \
+    curl -fL "https://api.github.com/repos/direnv/direnv/releases/$release" $authorization_args \
     | grep browser_download_url \
     | cut -d '"' -f 4 \
     | grep "direnv.$kernel.$machine\$"


### PR DESCRIPTION
When running in a CI environment we sometimes experience rate limiting from the GitHub API when trying to run direnv's install.sh. This causes the whole build to fail, which can be frustrating.

The Homebrew project has previously worked around a similar issue by allowing the user to optionally authenticate using their personal GitHub account, which results in a higher rate limit on API usage. (See `HOMEBREW_GITHU_API_TOKEN` docs here: https://docs.brew.sh/Manpage).

This PR introduces a similar optional environment variable for direnv's install.sh script, which will allow us to inject a dedicated authentication token into our CI builds and avoid spurious failures.

I wasn't sure if you'd want a note added in `docs/installation.md` - please just let me know if you would and I'll add it.

The only other thing that I'm just noticing is that it seems that the convention in this script is for lower case environment variables as inputs - would you like me to change that?