### PR TITLE
fix: escape newlines in generated vimscript

### DIFF
--- a/internal/cmd/shell_vim.go
+++ b/internal/cmd/shell_vim.go
@@ -47,5 +47,5 @@ func (sh vim) escapeKey(str string) string {
 
 // TODO: Make sure this escaping is valid
 func (sh vim) escapeValue(str string) string {
-	return "'" + strings.Replace(str, "'", "''", -1) + "'"
+	return "'" + strings.Replace(strings.Replace(str, "\n", "\\n", -1), "'", "''", -1) + "'"
 }


### PR DESCRIPTION
I haven't tested this, but something like this should work.

Fixes #1346 