### PR TITLE
test: simplify tests with t.Setenv

### DIFF
--- a/pkg/dotenv/parse_test.go
+++ b/pkg/dotenv/parse_test.go
@@ -1,7 +1,6 @@
 package dotenv_test
 
 import (
-	"os"
 	"testing"
 
 	dotenv "github.com/direnv/direnv/v2/pkg/dotenv"
@@ -237,10 +236,7 @@ OPTION_A1="$OPTION_A/bar/${OPTION_H}/$FOO"
 `
 
 func TestVariableExpansion(t *testing.T) {
-	err := os.Setenv("FOO", "foo")
-	if err != nil {
-		t.Fatalf("unable to set environment variable for testing: %s", err)
-	}
+	t.Setenv("FOO", "foo")
 
 	env := dotenv.MustParse(TestVariableExpansionEnv)
 	shouldNotHaveEmptyKey(t, env)
@@ -297,10 +293,7 @@ OPTION_S="${BAR:-:-}"
 `
 
 func TestVariableExpansionWithDefaults(t *testing.T) {
-	err := os.Setenv("FOO", "foo")
-	if err != nil {
-		t.Fatalf("unable to set environment variable for testing: %s", err)
-	}
+	t.Setenv("FOO", "foo")
 
 	env := dotenv.MustParse(TestVariableExpansionWithDefaultsEnv)
 	shouldNotHaveEmptyKey(t, env)


### PR DESCRIPTION
The PR simplifies parse tests by refactoring code to use [`T.Setenv`](https://pkg.go.dev/testing#T.Setenv) instead of `os.Setenv`.

`T.Setenv` calls `os.Setenv(key, value)` and uses `T.Cleanup` to restore the environment variable to its original value after the test. So, the test doesn't need to restore the environment by itself.
