### PR TITLE
Add ignore_paths

### DIFF
--- a/internal/cmd/cmd_export.go
+++ b/internal/cmd/cmd_export.go
@@ -30,6 +30,14 @@ var CmdExport = &Cmd{
 func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 	defer log.SetPrefix(log.Prefix())
 	log.SetPrefix(log.Prefix() + "export:")
+
+	for _, ignorePath := range config.IgnorePaths {
+		if strings.HasPrefix(config.WorkDir, ignorePath) {
+			logDebug("ignoring directory %s", config.WorkDir)
+			return
+		}
+	}
+
 	logDebug("start")
 
 	var target string

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	WarnTimeout     time.Duration
 	WhitelistPrefix []string
 	WhitelistExact  map[string]bool
+	IgnorePaths     []string
 }
 
 type tomlDuration struct {
@@ -62,6 +63,7 @@ type tomlGlobal struct {
 	HideEnvDiff  bool          `toml:"hide_env_diff"`
 	LogFormat    string        `toml:"log_format"`
 	LogFilter    string        `toml:"log_filter"`
+	IgnorePaths  []string      `toml:"ignore_paths"`
 }
 
 type tomlWhitelist struct {
@@ -125,6 +127,8 @@ func LoadConfig(env Env) (config *Config, err error) {
 	config.WhitelistPrefix = make([]string, 0)
 	config.WhitelistExact = make(map[string]bool)
 
+	config.IgnorePaths = make([]string, 0)
+
 	// Load the TOML config
 	config.TomlPath = filepath.Join(config.ConfDir, "direnv.toml")
 	if _, statErr := os.Stat(config.TomlPath); statErr != nil {
@@ -179,6 +183,13 @@ func LoadConfig(env Env) (config *Config, err error) {
 			}
 
 			config.WhitelistExact[expandTildePath(path)] = true
+		}
+
+		for _, path := range tomlConf.IgnorePaths {
+			if !strings.HasSuffix(path, "/") {
+				path += "/"
+			}
+			config.IgnorePaths = append(config.IgnorePaths, expandTildePath(path))
 		}
 
 		if tomlConf.SkipDotenv {

--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -92,6 +92,17 @@ Sets the log format for direnv outputs. Set to "-" to disable normal logging.
 .PP
 A Regexp that can be used to filter out some of the logs.
 
+.SS \fBignore_paths\fR
+.PP
+A list of directories to be ignored from being evaluated by direnv. This can be useful to avoid evaluating .envrc files in directories that are known to be slow or that contain untrusted code.
+
+.PP
+Example:
+
+.EX
+ignore_paths = [ "/run", "/tmp" ]
+.EE
+
 .SH [whitelist]
 .PP
 Specifying whitelist directives marks specific directory hierarchies or specific directories as "trusted" -- direnv will evaluate any matching .envrc files regardless of whether they have been specifically allowed. \fBThis feature should be used with great care\fP, as anyone with the ability to write files to that directory (including collaborators on VCS repositories) will be able to execute arbitrary code on your computer.

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -78,6 +78,16 @@ Sets the log format for direnv outputs. Set to "-" to disable normal logging.
 
 A Regexp that can be used to filter out some of the logs.
 
+### `ignore_paths`
+
+A list of directories to be ignored from being evaluated by direnv. This can be useful to avoid evaluating .envrc files in directories that are known to be slow or that contain untrusted code.
+
+Example:
+
+```toml
+ignore_paths = [ "/run", "/tmp" ]
+```
+
 ## [whitelist]
 
 Specifying whitelist directives marks specific directory hierarchies or specific directories as "trusted" -- direnv will evaluate any matching .envrc files regardless of whether they have been specifically allowed. **This feature should be used with great care**, as anyone with the ability to write files to that directory (including collaborators on VCS repositories) will be able to execute arbitrary code on your computer.


### PR DESCRIPTION
This pull request adds a new config option to `direnv.toml`:

```toml
ignore_paths = ["/run", "/tmp"]
```

If a path is in the ignore list, every directory in it is ignored. This is useful for specifying network directories, in which direnv is very slow, which causes large delays at each directory change.