### PR TITLE
docs: note direnv version for log_{format,filter}

### DIFF
--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -88,9 +88,15 @@ Set to \fBtrue\fR to hide the diff of the environment variables when loading the
 .PP
 Sets the log format for direnv outputs. Set to "-" to disable normal logging.
 
+.PP
+direnv >= 2.36.0 is required
+
 .SS \fBlog_filter\fR
 .PP
 A Regexp that can be used to filter out some of the logs.
+
+.PP
+direnv >= 2.36.0 is required
 
 .SH [whitelist]
 .PP

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -74,9 +74,13 @@ Set to `true` to hide the diff of the environment variables when loading the
 
 Sets the log format for direnv outputs. Set to "-" to disable normal logging.
 
+> direnv >= 2.36.0 is required
+
 ### `log_filter`
 
 A Regexp that can be used to filter out some of the logs.
+
+> direnv >= 2.36.0 is required
 
 ## [whitelist]
 


### PR DESCRIPTION
These new configuration fields were recently introduced in #1336 and will be included in the next minor version (presumably v2.36.0).

This makes it clearer that these options aren't available in older released versions.

The annotation format is the same as what is used for 'load_dotenv'.