### PR TITLE
Add `use_flox` to stdlib.sh

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1301,6 +1301,68 @@ use_flake() {
   nix --extra-experimental-features "nix-command flakes" profile wipe-history --profile "$(direnv_layout_dir)/flake-profile"
 }
 
+# Usage: use_flox [...]
+#
+# Load environment variables from `flox activate`. By default uses the .flox
+# directory in the current directory.
+#
+# You can specify a remote environment with '--remote=<owner>/<name>' where
+# <owner>/<name> is the FloxHub environment name (e.g. `use_flox --remote=myorg/env`).
+#
+# The '--trust' flag can be added to automatically trust remote environments:
+#    use_flox --trust --remote=myorg/env
+#
+# An alternate local environment directory can be specified with '--dir=<path>',
+# where <path> contains a .flox directory.
+#
+# Example:
+#
+#    use_flox --remote=acme/production
+#    use_flox --dir=/path/to/env
+#
+# Note: Custom commands are not supported since flox activate is used for loading.
+function use_flox() {
+    local flox_dir=".flox"
+    local args=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dir=*)
+                flox_dir="${1#*=}"/.flox
+                args+=("$1")
+                shift
+                ;;
+            --dir)
+                if [[ $# -lt 2 ]]; then
+                    printf "direnv(use_flox): --dir flag requires a path argument\n" >&2
+                    return 1
+                fi
+                flox_dir="$2"/.flox
+                args+=("$1" "$2")
+                shift 2
+                ;;
+            *)
+                args+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    if [[ ! -d "$flox_dir" ]]; then
+        printf "direnv(use_flox): \`.flox\` directory not found at %s\n" "$flox_dir" >&2
+        printf "direnv(use_flox): Did you run \`flox init\` in this directory?\n" >&2
+        return 1
+    fi
+
+    direnv_load flox activate "${args[@]}" -- "$direnv" dump
+
+    if [[ ${#args[@]} -eq 0 ]]; then
+        watch_dir "$flox_dir/env/"
+        watch_file "$flox_dir/env.json"
+        watch_file "$flox_dir/env.lock"
+    fi
+}
+
 # Usage: use_guix [...]
 #
 # Load environment variables from `guix shell`.


### PR DESCRIPTION
This is roughly a copy of https://github.com/flox/flox-direnv - tagging its contributors: @rossturk @bryanhonof @dcarley lmk if this looks good to you or if you're opposed to bringing `use_flox` here.
