### PR TITLE
install script permits args now and uses printf

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 { # Prevent execution if this script was only partially downloaded
 
   log() {
-    echo "[installer] $*" >&2
+    printf "[installer] %s\n" "$*" >&2
   }
 
   die() {
@@ -18,14 +18,26 @@ set -euo pipefail
   at_exit() {
     ret=$?
     if [[ $ret -gt 0 ]]; then
-      log "the script failed with error $ret.\n" \
-        "\n" \
-        "To report installation errors, submit an issue to\n" \
-        "    https://github.com/direnv/direnv/issues/new/choose"
+      log "the script failed with error ${ret}.\n" \
+      "To report installation errors, submit an issue to\n" \
+      "https://github.com/direnv/direnv/issues/new/choose"
     fi
     exit "$ret"
   }
   trap at_exit EXIT
+
+  if [ $# -ge 1 ];then
+    if [ "${1}x" == "--helpx" ] || [ "${1}x" == "-hx" ];then
+      printf "USAGE: ./install-direnv.sh [bin_path]\n"
+      printf "bin_path=~/.local/bin ./install-direnv.sh\n"
+      exit 0
+    elif [ -d "$(realpath "$1")" ] && [ -w "$(realpath "$1")" ]; then
+      bin_path="$(realpath "$1")"
+    else
+      log "bin_path ${1} does not exist or is not writeable" >&2
+      exit 1
+    fi
+  fi
 
   kernel=$(uname -s | tr "[:upper:]" "[:lower:]")
   case "${kernel}" in
@@ -66,9 +78,12 @@ set -euo pipefail
         break
       fi
     done
+    if [[ -z "$bin_path" || -w $bin_path ]]; then
+      die "did not find a writeable path in $PATH"
+    fi
   fi
-  if [[ -z "$bin_path" ]]; then
-    die "did not find a writeable path in $PATH"
+  if ! [[ -w "$bin_path" ]]; then
+    die "bin_path ${bin_path} is not writeable"
   fi
   echo "bin_path=$bin_path"
 


### PR DESCRIPTION
I want to use the installer to run it with ansible's script module. There i can't set an environment variable and I don't like the idea to just take the first thing from $PATH. I like to download install scripts and to have a look what they are doing. And maybe then I add them to an ansible role.

Now one can specify the `$bin_path` as `$1` or ask for `--help` or `-h`. Arguments overwrite environment variables. I checked this with shellcheck and everything was fine. And I checked the documented use case and my added use case.