### PR TITLE
A more universal fix for the python 3.14 `find_spec` deprecation warning

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -837,7 +837,7 @@ layout_python() {
   else
     local python_version ve
     # shellcheck disable=SC2046
-    read -r python_version ve <<<$($python -c "import importlib.util as u, platform as p;ve='venv' if u.find_spec('venv') else ('virtualenv' if u.find_spec('virtualenv') else '');print('.'.join(p.python_version_tuple()[:2])+' '+ve)")
+    read -r python_version ve <<<$(echo -e 'import platform as p\ntry:\n import venv\n ve="venv"\nexcept Exception:\n try:\n  import virtualenv\n  ve="virtualenv"\n except Exception:\n  ve=""\nprint(p.python_version()+" "+ve)' | $python)
     if [[ -z $python_version ]]; then
       log_error "Could not find python's version"
       return 1

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -837,7 +837,20 @@ layout_python() {
   else
     local python_version ve
     # shellcheck disable=SC2046
-    read -r python_version ve <<<$(echo -e 'import platform as p\ntry:\n import venv\n ve="venv"\nexcept Exception:\n try:\n  import virtualenv\n  ve="virtualenv"\n except Exception:\n  ve=""\nprint(p.python_version()+" "+ve)' | $python)
+    read -r python_version ve <<<$($python <<EOF
+import platform as p
+try:
+ import venv
+ ve="venv"
+except Exception:
+ try:
+   import virtualenv
+   ve="virtualenv"
+ except Exception:
+   ve=""
+print(p.python_version()+" "+ve)
+EOF
+)
     if [[ -z $python_version ]]; then
       log_error "Could not find python's version"
       return 1


### PR DESCRIPTION
The fix merged by #1176 cleans up the deprecation warning, but breaks for all python versions prior to 3.4.  This change uses some simple try/except blocks to successively look for `venv` or `virtualenv` without version checking or conditional imports:

```python
import platform as p
try:
 import venv
 ve="venv"
except Exception:
 try:
  import virtualenv
  ve="virtualenv"
 except Exception:
  ve=""
print(p.python_version()+" "+ve)
```