### PR TITLE
assert minimum powershell version

### DIFF
--- a/internal/cmd/shell_pwsh.go
+++ b/internal/cmd/shell_pwsh.go
@@ -11,7 +11,10 @@ type pwsh struct{}
 var Pwsh Shell = pwsh{}
 
 func (sh pwsh) Hook() (string, error) {
-	const hook = `using namespace System;
+	const hook = `if ($PSVersionTable.PSVersion.Major -lt 7) {
+    throw "direnv: powershell version $($PSVersionTable.PSVersion) does not meet the minimum required version 7!"
+}
+using namespace System;
 using namespace System.Management.Automation;
 
 $hook = [EventHandler[LocationChangedEventArgs]] {


### PR DESCRIPTION
when running `direnv` on an older version of powershell, every new shell produces this error:
```
Unable to find type [LocationChangedEventArgs].
At line:1 char:81
+ ... .Automation;  $hook = [EventHandler[LocationChangedEventArgs]] {   pa ...
+                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (LocationChangedEventArgs:TypeName) [], RuntimeExcep
   tion
    + FullyQualifiedErrorId : TypeNotFound

The property 'LocationChangedAction' cannot be found on this object. Verify that the property exists
and can be set.
At line:1 char:647
+ ...  } else {   $ExecutionContext.SessionState.InvokeCommand.LocationChan ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : PropertyAssignmentException

```

this would be nicer:
```
Exception:
Line |
   2 |      throw "direnv: powershell version $($PSVersionTable.PSVersion) do …
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | direnv: powershell version 7.5.0 does not meet the minimum required version 7!
```