### PR TITLE
Don't give an error when the current directory doesn't exist

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -109,8 +109,9 @@ func LoadConfig(env Env) (config *Config, err error) {
 	exePath = strings.Replace(exePath, "\\", "/", -1)
 	config.SelfPath = exePath
 
-	if config.WorkDir, err = os.Getwd(); err != nil {
-		err = fmt.Errorf("LoadConfig() Getwd failed: %w", err)
+	var wdErr error
+	if config.WorkDir, wdErr = os.Getwd(); wdErr != nil {
+		// handled by `findEnvUp`
 		return
 	}
 

--- a/internal/cmd/rc.go
+++ b/internal/cmd/rc.go
@@ -388,6 +388,9 @@ func findEnvUp(searchDir string, loadDotenv bool) (path string) {
 }
 
 func findUp(searchDir string, fileNames ...string) (path string) {
+	if searchDir == "" {
+		return ""
+	}
 	for _, dir := range eachDir(searchDir) {
 		for _, fileName := range fileNames {
 			path := filepath.Join(dir, fileName)


### PR DESCRIPTION
This just indicates that there is no configuration for the current directory; it doesn't need to generate logging.

Fixes https://github.com/direnv/direnv/issues/455