### PR TITLE
Add `.envrc` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.sw?
 .direnv
 .gopath
+/.envrc
 /direnv
 /direnv.test
 /dist


### PR DESCRIPTION
It's useful to have `use flake` in `.envrc` while working on this repo, but then one needs to manually remember not to accidentally commit it, since it was intentionally removed in a0c7fd44ea3d865b75f508fdff8e1bb08d27d866. This PR just adds `.envrc` to the `.gitignore`, but uses a leading slash to ensure that it's only ignored at the repo root.