### PR TITLE
Add `use_nix_installables` to load env from `nix shell`.

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1331,6 +1331,22 @@ use_flake() {
   nix --extra-experimental-features "nix-command flakes" profile wipe-history --profile "$(direnv_layout_dir)/flake-profile"
 }
 
+# Usage: use_nix_installables [...]
+#
+# Load environment with `nix shell` for the given nix-installables.
+#
+# For example, 'nixpkgs#ruby' or 'github:NixOS/nixpkgs/nixpkgs-unstable/ruby'.
+# See also https://nix.dev/manual/nix/stable/command-ref/new-cli/nix#installables
+use_nix_installables() {
+  if [[ $# -lt 1 ]]; then
+    printf "direnv(use_nix_installables): expected at least one nix-installable.\n" >&2
+    printf "direnv(use_nix_installables): For example 'nixpkgs#ruby' or 'github:nixos/nixpkgs#ruby'.\n" >&2
+    printf "direnv(use_nix_installables): See also https://nix.dev/manual/nix/stable/command-ref/new-cli/nix#installables\n" >&2
+    return 1
+  fi
+  direnv_load nix shell "${@}" -c "$direnv" dump
+}
+
 # Usage: use_flox [...]
 #
 # Load environment variables from `flox activate`. By default uses the .flox


### PR DESCRIPTION
This allows people to quickly setup an environment with the provided [nix-installables][1] (outputs from flakes).


For example, one could use the following line to get node and latest development-gleam.

```
use nix_installables nixpkgs#nodejs github:vic/gleam-nix
```

This tiny `use_nix_installables` was first created by @vic as part of the [nix-versions][2] utility, that resolves installables to their nixpkgs-revision for specific package versions.

However, it can be of use to any nix user since it only depends on `direnv` and `nix shell`. If this PR gets merged, I'll update the wiki on the Nix page to document this new nix related function.


```
> curl https://nix-versions.alwaysdata.net/use_nix_tools.sh/go/ruby
use_nix_installables() {
    direnv_load nix shell "${@}" -c $direnv dump
}
use nix_installables nixpkgs/de0fe30#go_1_24 nixpkgs/0d53485#ruby_3_4
```



[1]: https://nix.dev/manual/nix/2.24/command-ref/new-cli/nix#installables
[2]: https://nix-versions.alwaysdata.net/tools-version-manager.html