### PR TITLE
doc: fix link to guix manual

### DIFF
--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -336,7 +336,7 @@ Load environment variables from `guix shell`.
 
 Any arguments given will be passed to guix shell. For example, `use guix hello` would setup an environment including the hello package. To create an environment with the hello dependencies, the `--development` flag is used `use guix --development hello`. Other options include `--file` which allows loading an environment from a file.
 
-See https://guix.gnu.org/en/manual/en/guix.html#Invoking-guix-shell
+See https://guix.gnu.org/manual/en/guix.html#Invoking-guix-shell
 
 ### `rvm [...]`
 


### PR DESCRIPTION
the original link leads to a 404 page.