### PR TITLE
use_nix: always restore special variables

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1299,16 +1299,16 @@ use_nix() {
     ["terminfo"]=${terminfo:-__UNSET__}
   )
   direnv_load nix-shell --show-trace "$@" --run "$(join_args "$direnv" dump)"
-  if [[ $# == 0 ]]; then
-    for key in "${!values_to_restore[@]}"; do
-      local value=${values_to_restore[$key]}
-      if [[ $value == __UNSET__ ]]; then
-        unset "$key"
-      else
-        export "$key=$value"
-      fi
-    done
+  for key in "${!values_to_restore[@]}"; do
+    local value=${values_to_restore[$key]}
+    if [[ $value == __UNSET__ ]]; then
+      unset "$key"
+    else
+      export "$key=$value"
+    fi
+  done
 
+  if [[ $# == 0 ]]; then
     watch_file default.nix shell.nix
   fi
 }


### PR DESCRIPTION
https://github.com/direnv/direnv/pull/1409 added code to restore special envvars (yay), but it was inside the check which only happens when there are no arguments.

Moving the code block up means this works in cases like `use nix -p go`, not only `use nix`.