### PR TITLE
add trailing newline to error messages

### DIFF
--- a/internal/cmd/mod.go
+++ b/internal/cmd/mod.go
@@ -24,7 +24,7 @@ func Main(env Env, args []string, modBashPath string, modStdlib string, modVersi
 
 	err := CommandsDispatch(env, args)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, errorColor+"%sdirenv: error %v%s\n", errorColor, err, clearColor)
+		fmt.Fprintf(os.Stderr, "%sdirenv: error %v%s\n", errorColor, err, clearColor)
 	}
 	return err
 }

--- a/internal/cmd/mod.go
+++ b/internal/cmd/mod.go
@@ -24,7 +24,7 @@ func Main(env Env, args []string, modBashPath string, modStdlib string, modVersi
 
 	err := CommandsDispatch(env, args)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, errorColor+"%sdirenv: error %v%s", errorColor, err, clearColor)
+		fmt.Fprintf(os.Stderr, errorColor+"%sdirenv: error %v%s\n", errorColor, err, clearColor)
 	}
 	return err
 }


### PR DESCRIPTION
Fixes a regression in #1336, which caused error messages to display poorly (or in some cases not at all). See the linked issues.

Fixes #1425
Fixes #1431

Also deletes a duplicate ansi escape code.