### PR TITLE
Detect ble.sh and use blehook PRECMD instead of PROMPT_COMMAND if available

### DIFF
--- a/internal/cmd/shell_bash.go
+++ b/internal/cmd/shell_bash.go
@@ -15,7 +15,9 @@ _direnv_hook() {
   trap - SIGINT;
   return $previous_exit_status;
 };
-if [[ ";${PROMPT_COMMAND[*]:-};" != *";_direnv_hook;"* ]]; then
+if [[ ''${BLE_VERSION-} && _ble_version -ge 400 ]]; then
+  blehook PRECMD!="_direnv_hook"
+elif [[ ";${PROMPT_COMMAND[*]:-};" != *";_direnv_hook;"* ]]; then
   if [[ "$(declare -p PROMPT_COMMAND 2>&1)" == "declare -a"* ]]; then
     PROMPT_COMMAND=(_direnv_hook "${PROMPT_COMMAND[@]}")
   else


### PR DESCRIPTION
I encountered a bug with [Starship](https://github.com/starship/starship) where it would load the prompt before direnv, meaning my prompt was wrong whenever I entered or left a directory that had direnv.

This change uses the `blehook` functionality provided by [ble.sh](https://github.com/akinomyoga/ble.sh) (which is also what Starship uses) to run direnv earlier in the sequence. This fixes that bug with Statship.