### PR TITLE
pre-built github action for direnv

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -186,3 +186,4 @@ jobs:
 - [GitHub Actions Environment Files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files)
 - [direnv Documentation](https://direnv.net)
 - [direnv-stdlib(1)](../man/direnv-stdlib.1.md)
+- [direnv-load-and-mask](https://github.com/iloveitaly/github-action-direnv-load-and-mask) GitHub action to load direnv into the GitHub environment and intelligently mask sensitive variables.


### PR DESCRIPTION
- **fix typos in const, comments, and CHANGELOG**
- **build(deps): bump actions/setup-go from 5.1.0 to 5.2.0**
- **README: list mise as an alternative**
- **fix: escape newlines in generated vimscript (#1347)**
- **build(deps): bump actions/setup-go from 5.2.0 to 5.3.0**
- **build(deps): bump actions/setup-python from 5.3.0 to 5.4.0**
- **feat: Upgrade go 1.20->1.24**
- **fix: downgrade to 1.23**
- **fix: downgrade to 1.22**
- **fix: remove gomod2nix pkgs inherit, back to 1.24**
- **docs: go version**
- **fix: FileTime pointer for golangci-lint**
- **chore: add missing brews**
- **chore: revert golangci.yml**
- **chore: debug golangci-lint vers**
- **feat: nix go1.24?**
- **feat: nix go1.24?**
- **chore: remove golangci-lint version debug**
- **chore: dont upgrade version.txt yet**
- **chore: cleanup comments**
- **add support to fully reproducible guix shells (#1392)**
- **stdlib: use_guix: Enable the watching of Guix related files.**
- **build(deps): bump cachix/install-nix-action from 30 to 31**
- **build(deps): bump actions/setup-go from 5.3.0 to 5.4.0**
- **Add `.envrc` to `.gitignore` (#1397)**
- **build(deps): bump github.com/BurntSushi/toml from 1.4.0 to 1.5.0 (#1403)**
- **Don't give an error when the current directory doesn't exist (#1395)**
- **man: Correct duplicate usage of 'with' in the direnv(1) (#1394)**
- **assert minimum powershell version (#1385)**
- **optionally authenticate against github api during install (#1337)**
- **docs: note direnv version for log_{format,filter} (#1369)**
- **build(deps): bump actions/setup-python from 5.4.0 to 5.5.0**
- **install.sh: fix empty array error (#1406)**
- **use_nix: unset TMPDIR variables**
- **fix golang lint error**
- **A more universal fix for the python 3.14 `find_spec` deprecation warning**
- **layout_python: make python version check more readable**
- **build(deps): bump golang.org/x/mod from 0.19.0 to 0.21.0**
- **update gomod2nix**
- **Use PROMPT_COMMAND shortcut found in zoxide**
- **Revert "Use PROMPT_COMMAND shortcut found in zoxide" (#1413)**
- **Add `use_flox` to stdlib.sh (#1372)**
- **Release v2.36.0**
- **Revert "Release v2.36.0"**
- **Release v2.36.0**
- **document how to make it a release**
- **doc: fix link to guix manual**
- **use_nix: always restore special variables**
- **Do not include the patch level in the Python venv name**
- **add trailing newline to error messages**
- **chore(deps): bump actions/setup-python from 5.5.0 to 5.6.0**
- **delete duplicate ansi escape code**
- **chore(deps): bump actions/setup-go from 5.4.0 to 5.5.0**
- **feat: add windows arm64 target**
- **chore(deps): bump golang.org/x/mod from 0.24.0 to 0.25.0**
- **update gomod2nix**
- **refactor "export pwsh" using verbatim envvar names and verbatim strings (#1448)**
- **fix: accept true as valid DIRENV_DEBUG value (#1365)**
- **man: document sub-commands**
- **man: re-generate manpages**
- **docs: add github-actions page**
- **feat(direnv export gha): stenghten export format**
- **refactor: better error handling for Dump and Error**
- **automate release creation**
- **add a `make help` task to list all commands**
- **CONTRIBUTING: update release process**
- **Makefile: pass version/repository as arguments to prepare-release script**
- **make workflows ready for merge queue**
- **go: enable caching**
- **enable magic-nix-cache**
- **also enable actions/cache for golang inside the nix build**
- **drop golang caching from nix build again**
- **build tests/dist with nix-fast-build instead of impure runs**
- **migrate to version 2 of golangci lint**
- **address all new golangci linter issues**
- **flake.nix now provides the reference go version**
- **ci/nix: don't fail ci fast**
- **Release v2.37.0**
- **prepare-release: don't pass --delete-branch**
- **fix changelog extraction**
- **docs: add pre-build github action**
