### PR TITLE
fix regression in displaying export errors

### DIFF
--- a/internal/cmd/cmd_export.go
+++ b/internal/cmd/cmd_export.go
@@ -104,9 +104,9 @@ func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 		logStatus(config, "export %s", out)
 	}
 
-	diffString, err := currentEnv.Diff(newEnv).ToShell(shell)
-	if err != nil {
-		return fmt.Errorf("ToShell() failed: %w", err)
+	diffString, diffErr := currentEnv.Diff(newEnv).ToShell(shell)
+	if diffErr != nil {
+		return fmt.Errorf("ToShell() failed: %w", diffErr)
 	}
 	logDebug("env diff %s", diffString)
 	fmt.Print(diffString)


### PR DESCRIPTION
Fixes a regression introduced by cf9222e.

At this point in the control flow, `err` is non-nil if there was an error in config.EnvFromRC. We depend on it remaining non-nil until the return statement. cf9222e inadvertently unconditionally overwrote `err`, causing this function to never report errors from config.EnvFromRC. Fixed by giving the new error a different name.

You can test the issue by editing this repo's .envrc file and then running `go run . export bash`.

Fixes #1463