### PR TITLE
Disable status logging with `log_format = "-"`

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -155,8 +155,11 @@ func LoadConfig(env Env) (config *Config, err error) {
 		format, ok := env["DIRENV_LOG_FORMAT"]
 		if ok {
 			config.LogFormat = format
-		} else if global.LogFormat != "" {
-			config.LogFormat = global.LogFormat
+		} else if logFmt := global.LogFormat; logFmt != "" {
+			if logFmt == "-" {
+				logFmt = ""
+			}
+			config.LogFormat = logFmt
 		}
 
 		if global.LogFilter != "" {


### PR DESCRIPTION
Treat the `-` value of the `log_format` option specially to match the [documented behavior](https://github.com/direnv/direnv/blob/v2.37.1/man/direnv.toml.1.md#log_format).

Fixes #1419