### PR TITLE
shell/{bash,zsh}: don't block SIGINT why evaluating .envrc

### DIFF
--- a/internal/cmd/shell_bash.go
+++ b/internal/cmd/shell_bash.go
@@ -10,8 +10,9 @@ var Bash Shell = bash{}
 const bashHook = `
 _direnv_hook() {
   local previous_exit_status=$?;
+  vars="$("{{.SelfPath}}" export bash)";
   trap -- '' SIGINT;
-  eval "$("{{.SelfPath}}" export bash)";
+  eval "$vars";
   trap - SIGINT;
   return $previous_exit_status;
 };

--- a/internal/cmd/shell_zsh.go
+++ b/internal/cmd/shell_zsh.go
@@ -8,8 +8,9 @@ var Zsh Shell = zsh{}
 
 const zshHook = `
 _direnv_hook() {
+  vars="$("{{.SelfPath}}" export zsh)"
   trap -- '' SIGINT
-  eval "$("{{.SelfPath}}" export zsh)"
+  eval "$vars"
   trap - SIGINT
 }
 typeset -ag precmd_functions


### PR DESCRIPTION
this particular annoying in slow hooks that need to download/build for a long time and cannot be aborted.