### PR TITLE
feat: `global.flatSearchDirs` config option

### DIFF
--- a/internal/cmd/cmd_exec.go
+++ b/internal/cmd/cmd_exec.go
@@ -52,7 +52,7 @@ func cmdExecAction(env Env, args []string, config *Config) (err error) {
 	previousEnv.CleanContext()
 
 	// Load the rc
-	if toLoad := findEnvUp(rcPath, config.LoadDotenv); toLoad != "" {
+	if toLoad := findEnv(rcPath, config.LoadDotenv, config.FlatSearchDirs); toLoad != "" {
 		if newEnv, err = config.EnvFromRC(toLoad, previousEnv); err != nil {
 			return
 		}

--- a/internal/cmd/cmd_export.go
+++ b/internal/cmd/cmd_export.go
@@ -45,7 +45,7 @@ func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 
 	logDebug("loading RCs")
 	loadedRC := config.LoadedRC()
-	toLoad := findEnvUp(config.WorkDir, config.LoadDotenv)
+	toLoad := findEnv(config.WorkDir, config.LoadDotenv, config.FlatSearchDirs)
 
 	if loadedRC == nil && toLoad == "" {
 		return

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	LogFilter       *regexp.Regexp
 	LogColor        bool
 	WarnTimeout     time.Duration
+	FlatSearchDirs  []string
 	WhitelistPrefix []string
 	WhitelistExact  map[string]bool
 }
@@ -53,15 +54,16 @@ type tomlConfig struct {
 }
 
 type tomlGlobal struct {
-	BashPath     string        `toml:"bash_path"`
-	DisableStdin bool          `toml:"disable_stdin"`
-	StrictEnv    bool          `toml:"strict_env"`
-	SkipDotenv   bool          `toml:"skip_dotenv"` // deprecated, use load_dotenv
-	LoadDotenv   bool          `toml:"load_dotenv"`
-	WarnTimeout  *tomlDuration `toml:"warn_timeout"`
-	HideEnvDiff  bool          `toml:"hide_env_diff"`
-	LogFormat    string        `toml:"log_format"`
-	LogFilter    string        `toml:"log_filter"`
+	BashPath       string        `toml:"bash_path"`
+	DisableStdin   bool          `toml:"disable_stdin"`
+	StrictEnv      bool          `toml:"strict_env"`
+	SkipDotenv     bool          `toml:"skip_dotenv"` // deprecated, use load_dotenv
+	LoadDotenv     bool          `toml:"load_dotenv"`
+	WarnTimeout    *tomlDuration `toml:"warn_timeout"`
+	HideEnvDiff    bool          `toml:"hide_env_diff"`
+	LogFormat      string        `toml:"log_format"`
+	LogFilter      string        `toml:"log_filter"`
+	FlatSearchDirs []string      `toml:"flat_search_dirs"`
 }
 
 type tomlWhitelist struct {
@@ -196,6 +198,7 @@ func LoadConfig(env Env) (config *Config, err error) {
 		if tomlConf.WarnTimeout != nil {
 			config.WarnTimeout = tomlConf.WarnTimeout.Duration
 		}
+		config.FlatSearchDirs = tomlConf.FlatSearchDirs
 	}
 
 	if ts := env.Fetch("DIRENV_WARN_TIMEOUT", ""); ts != "" {

--- a/man/direnv.toml.1
+++ b/man/direnv.toml.1
@@ -96,6 +96,14 @@ direnv >= 2.36.0 is required
 
 .RE
 
+.SS \fBflat_search_dirs\fR
+A list of directories that contain external (outside of the corresponding source tree) environment files. This is useful if the environment you use won't be added to the repository, and you don't want it to be a problem when dealing with version-control systems.
+
+Environment files in directories and in parent directories are prioritized over these.
+
+For example, if \fB/home/alice/envs\fR is added to the list, and the user enters the \fB/home/alice/project\fR directory, \fB/home/alice/envs\fR will be searched for \fBproject.envrc\fR, (\fBproject.env\fR), \fBproject/.envrc\fR and (\fBproject/.env\fR) in that order. The directories in parentheses are searched in respect to \fBload_dotenv\fR.
+
+
 .SH [whitelist]
 Specifying whitelist directives marks specific directory hierarchies or specific directories as "trusted" -- direnv will evaluate any matching .envrc files regardless of whether they have been specifically allowed. \fBThis feature should be used with great care\fP, as anyone with the ability to write files to that directory (including collaborators on VCS repositories) will be able to execute arbitrary code on your computer.
 

--- a/man/direnv.toml.1.md
+++ b/man/direnv.toml.1.md
@@ -82,6 +82,14 @@ A Regexp that can be used to filter out some of the logs.
 
 > direnv >= 2.36.0 is required
 
+### `flat_search_dirs`
+
+A list of directories that contain external (outside of the corresponding source tree) environment files. This is useful if the environment you use won't be added to the repository, and you don't want it to be a problem when dealing with version-control systems.
+
+Environment files in directories and in parent directories are prioritized over these.
+
+For example, if `/home/alice/envs` is added to the list, and the user enters the `/home/alice/project` directory, `/home/alice/envs` will be searched for `project.envrc`, (`project.env`), `project/.envrc` and (`project/.env`) in that order. The directories in parentheses are searched in respect to `load_dotenv`.
+
 ## [whitelist]
 
 Specifying whitelist directives marks specific directory hierarchies or specific directories as "trusted" -- direnv will evaluate any matching .envrc files regardless of whether they have been specifically allowed. **This feature should be used with great care**, as anyone with the ability to write files to that directory (including collaborators on VCS repositories) will be able to execute arbitrary code on your computer.


### PR DESCRIPTION
See the `direnv.toml.1.md` diff for how this works.

The intended use case is adding 1 directory to the list, but I made it a list to be more flexible, because I can imagine environments where that is necessary.

I considered the suggested solution in the issue, but in my opinion, that would introduce way too much unnecessary friction for the user. The way I implemented it still (sort of) allows for it though, so I think this should be fine.

Closes #1108