### PR TITLE
make it clear which commands are aliases in help output

### DIFF
--- a/internal/cmd/cmd_help.go
+++ b/internal/cmd/cmd_help.go
@@ -30,10 +30,14 @@ Available commands
 				}
 			} else {
 				fmt.Printf("%s%s:\n", cmd.Name, opts)
+				var aliases []string
 				for _, alias := range cmd.Aliases {
 					if alias[0:1] != "-" {
-						fmt.Printf("%s%s:\n", alias, opts)
+						aliases = append(aliases, alias)
 					}
+				}
+				if len(aliases) > 0 {
+					fmt.Printf("  aliases: %s\n", strings.Join(aliases, ", "))
 				}
 				fmt.Printf("  %s\n", cmd.Desc)
 			}


### PR DESCRIPTION
This is one potential solution to #1452
Rather than displaying aliases as individual commands, it groups them under the appropriate command.
I personally feel like an additional newline between each command could be nicer to read, but didn't want to make extra changes.

Previous output:
```
Available commands
------------------
allow [PATH_TO_RC]:
permit [PATH_TO_RC]:
grant [PATH_TO_RC]:
  Grants direnv permission to load the given .envrc or .env file.
block [PATH_TO_RC]:
deny [PATH_TO_RC]:
disallow [PATH_TO_RC]:
revoke [PATH_TO_RC]:
  Revokes the authorization of a given .envrc or .env file.
```

Adjusted output:
```
Available commands
------------------
allow [PATH_TO_RC]:
  aliases: permit, grant
  Grants direnv permission to load the given .envrc or .env file.
block [PATH_TO_RC]:
  aliases: deny, disallow, revoke
  Revokes the authorization of a given .envrc or .env file.
```