### PR TITLE
GetEnv: malformed variables trigger panic

### DIFF
--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 
@@ -12,7 +13,8 @@ import (
 type Env map[string]string
 
 // GetEnv turns the classic unix environment variables into a map of
-// key->values which is more handy to work with.
+// key->values which is more handy to work with. It skips over variables
+// that don't follow the "key=value" format.
 //
 // NOTE:  We don't support having two variables with the same name.
 // I've never seen it used in the wild but according to POSIX it's allowed.
@@ -21,7 +23,10 @@ func GetEnv() Env {
 
 	for _, kv := range os.Environ() {
 		kv2 := strings.SplitN(kv, "=", 2)
-
+		if len(kv2) < 2 {
+			fmt.Fprintf(os.Stderr, "direnv: Skipping invalid environment variable: %s\n", kv)
+			continue
+		}
 		key := kv2[0]
 		value := kv2[1]
 


### PR DESCRIPTION
The env variables returned by `os.Environ()` are supposed to follow a "key=value" format. But there are cases when the format is not followed and direnv panics.

The way I found this panic was by running direnv through `os/exec`:
```go
c := exec.Command("direnv")
c.Env = []string{"INVALID_BECAUSE_NO_EQUALS_SIGN"}
c.Run()
```
This commit makes `GetEnv` skip over malformed variables and log their values to stderr.

The root of the problem seems `exec.Command` not doing any validation, but I don't think that justifies a panic in direnv. I'll try to find why `exec.Command` allows invalid variables, but I don't think adding validation will be an easy/acceptable change on golang side.

I'm not sure how I could add a testcase for this change. Let me know where I could add a test.