### PR TITLE
Run command substitution separate from eval

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -789,7 +789,8 @@ layout_node() {
 # Sets environment variables from `opam env`.
 layout_opam() {
   export OPAMSWITCH=$PWD
-  local result="$(opam env "$@")"
+  local result
+  result="$(opam env "$@")"
   eval "$result"
 }
 


### PR DESCRIPTION
This has been bothering me for some time. The bug is that direnv always has a zero exit code, despite actually failing. Even after set -x, this still occurs.

The problem seems to be how eval works in Bash:

```
$ set -e; eval "$(exit 1)"; echo $?
0
```

Since `eval ""` is valid Bash, a non-zero exit status in command substitution is ignored. Saving this value to a temporary variable seems to avoid the issue.

I only changed the helpers that call a non-direnv process.