### PR TITLE
stdlib: use_flake: keep direnv environment alive by refreshing flake-profile timestamp

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1326,6 +1326,9 @@ use_nix() {
 use_flake() {
   watch_file flake.nix
   watch_file flake.lock
+  # Updating the flake-profile’s mtime prevents nh from GC’ing the frequently used direnv environment.
+  # Also remove any stale layout directory beforehand for a clean, consistent state.
+  rm -rf "$(direnv_layout_dir)"
   mkdir -p "$(direnv_layout_dir)"
   eval "$(nix --extra-experimental-features "nix-command flakes" print-dev-env --profile "$(direnv_layout_dir)/flake-profile" "$@")"
   nix --extra-experimental-features "nix-command flakes" profile wipe-history --profile "$(direnv_layout_dir)/flake-profile"


### PR DESCRIPTION
Hi! I use the [`nh`](https://github.com/nix-community/nh) tool to garbage-collect unused Nix environments—by default, it removes environments that haven’t been *recently used*. However, I recently noticed that it was also cleaning up environments that are actively used, but whose `flake-profile` file hadn’t been *recently created or modified*.

After some investigation, I found that `nh` determines whether an environment is “in use” based on the **modification time (mtime)** of the `flake-profile` file. Even if the environment is used daily via direnv, nh may incorrectly mark it for garbage collection if the timestamp is old.

This PR addresses the issue by **recreating the `direnv_layout_dir` (and thus the `flake-profile` file) on every setup**, ensuring the file gets a fresh timestamp. This change provides two benefits:

- **Prevents `nh` from GC’ing frequently used `direnv` environments** by keeping the `flake-profile`’s mtime up to date.  
- **Ensures a clean and consistent state** by removing any stale layout directory before recreation.
