### PR TITLE
fix: stdlib: support named pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+Unreleased
+==================
+
+  * fix: stdlib: dotenv, dotenv_if_exists: support named pipes (#1313)
+
 2.37.1 / 2025-07-20
 ==================
 

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -238,8 +238,10 @@ dotenv() {
   elif [[ -d $path ]]; then
     path=$path/.env
   fi
-  watch_file "$path"
-  if ! [[ -f $path ]]; then
+  if ! [[ -p $path ]]; then
+    watch_file "$path"
+  fi
+  if ! [[ -f $path || -p $path ]]; then
     log_error ".env at $path not found"
     return 1
   fi
@@ -257,8 +259,10 @@ dotenv_if_exists() {
   elif [[ -d $path ]]; then
     path=$path/.env
   fi
-  watch_file "$path"
-  if ! [[ -f $path ]]; then
+  if ! [[ -p $path ]]; then
+    watch_file "$path"
+  fi
+  if ! [[ -f $path || -p $path ]]; then
     return
   fi
   eval "$("$direnv" dotenv bash "$@")"

--- a/test/stdlib.bash
+++ b/test/stdlib.bash
@@ -40,6 +40,10 @@ test_name dotenv
   echo "export FOO=bar" > .env
   dotenv .env
   [[ $FOO = bar ]]
+
+  # Try to source a named pipe
+  dotenv <(echo "export BAR=baz")
+  [[ $BAR = baz ]]
 )
 
 test_name dotenv_if_exists
@@ -58,6 +62,10 @@ test_name dotenv_if_exists
   echo "export FOO=bar" > .env
   dotenv_if_exists .env
   [[ $FOO = bar ]]
+
+  # Try to source a named pipe
+  dotenv_if_exists <(echo "export BAR=baz")
+  [[ $BAR = baz ]]
 )
 
 test_name find_up


### PR DESCRIPTION
Closes #1313

I was trying to get direnv to work with 1Password's new [Access secrets from 1Password through local .env files](https://developer.1password.com/docs/environments/local-env-file) feature. However, the 1Password .env files are named pipes and `dotenv` function does not support named pipes. I already did this change locally by re-refining the functions in `$HOME/.config/direnv/direnvrc` file. I decided to try to upstream this change so that others can also benefit.