### PR TITLE
stdlib: add `load_netrc` to load credentials from `netrc` files

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -498,6 +498,31 @@ if on_git_branch; then
 fi
 .EE
 
+.SS \fBload_netrc [--file <netrc_file>] <machine> <login_var> <password_var> [<account_var>]\fR
+Loads credentials from a netrc file for the specified machine into the given
+variable names. The netrc file defaults to \fB~/.netrc\fR if not specified.
+
+.PP
+The function will read the netrc file, find the entry for the specified
+machine, and export the \fBlogin\fR, \fBpassword\fR, and optionally \fBaccount\fR values
+into the variables named by \fBlogin_var\fR, \fBpassword_var\fR, and \fBaccount_var\fR\&.
+
+.PP
+Pass \fBdefault\fR as the machine name to load credentials from the \fBdefault\fR
+entry in the netrc file.
+
+.PP
+The netrc file is automatically added to the watch list.
+
+.PP
+Example (.envrc):
+
+.EX
+load_netrc api.github.com GITHUB_USER GITHUB_TOKEN
+load_netrc --file /path/to/custom/netrc default MY_USER MY_PASS
+load_netrc api.example.com MY_USER MY_PASS MY_ACCOUNT
+.EE
+
 .SH COPYRIGHT
 MIT licence - Copyright (C) 2019 @zimbatm and contributors
 

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -465,6 +465,26 @@ Example (.envrc):
       echo "Thanks for contributing to a GitHub project!"
     fi
 
+### `load_netrc [--file <netrc_file>] <machine> <login_var> <password_var> [<account_var>]`
+
+Loads credentials from a netrc file for the specified machine into the given
+variable names. The netrc file defaults to `~/.netrc` if not specified.
+
+The function will read the netrc file, find the entry for the specified
+machine, and export the `login`, `password`, and optionally `account` values
+into the variables named by `login_var`, `password_var`, and `account_var`.
+
+Pass `default` as the machine name to load credentials from the `default`
+entry in the netrc file.
+
+The netrc file is automatically added to the watch list.
+
+Example (.envrc):
+
+    load_netrc api.github.com GITHUB_USER GITHUB_TOKEN
+    load_netrc --file /path/to/custom/netrc default MY_USER MY_PASS
+    load_netrc api.example.com MY_USER MY_PASS MY_ACCOUNT
+
 
 COPYRIGHT
 ---------

--- a/test/stdlib.bash
+++ b/test/stdlib.bash
@@ -193,6 +193,7 @@ test_name source_env_if_exists
   [[ $FOO = bar ]]
 
   # Expect correct path being logged
+  # shellcheck disable=SC2030
   export HOME=$workdir
   output="$(source_env_if_exists existing_file 2>&1 > /dev/null)"
   [[ "${output#*'loading ~/existing_file'}" != "$output" ]]
@@ -215,6 +216,184 @@ test_name env_vars_required
   [[ "${output#*'BAR is required'}" != "$output" ]]
   [[ "${output#*'BAZ is required'}" != "$output" ]]
   [[ "${output#*'MISSING is required'}" != "$output" ]]
+)
+
+test_name load_netrc
+(
+  load_stdlib
+
+  workdir=$(mktemp -d)
+  trap 'rm -rf "$workdir"' EXIT
+
+  cd "$workdir"
+
+  # Comprehensive netrc file covering: comments, macdef blocks, multi-line,
+  # single-line, multiple machines, and empty lines
+  cat > .netrc << 'EOF'
+# comment at top
+macdef init
+login fake_from_macro
+password fake_from_macro
+
+machine api.example.com
+  # inline comment
+  login testuser
+  password testpass123
+
+machine single.example.com login singleuser password singlepass
+
+machine reversed.example.com
+password reversedpass
+login reverseduser
+
+machine withaccount.example.com
+login acctuser
+password acctpass
+account acctvalue
+
+default
+login defaultuser
+password defaultpass
+EOF
+
+  # Test: multi-line format
+  load_netrc --file .netrc api.example.com MY_USER MY_PASS 2>/dev/null
+  assert_eq "$MY_USER" "testuser"
+  assert_eq "$MY_PASS" "testpass123"
+
+  # Test: single-line format
+  unset MY_USER MY_PASS
+  load_netrc --file .netrc single.example.com MY_USER MY_PASS 2>/dev/null
+  assert_eq "$MY_USER" "singleuser"
+  assert_eq "$MY_PASS" "singlepass"
+
+  # Test: password before login (reversed order)
+  unset MY_USER MY_PASS
+  load_netrc --file .netrc reversed.example.com MY_USER MY_PASS 2>/dev/null
+  assert_eq "$MY_USER" "reverseduser"
+  assert_eq "$MY_PASS" "reversedpass"
+
+  # Test: account variable
+  unset MY_USER MY_PASS MY_ACCOUNT
+  load_netrc --file .netrc withaccount.example.com MY_USER MY_PASS MY_ACCOUNT 2>/dev/null
+  assert_eq "$MY_USER" "acctuser"
+  assert_eq "$MY_PASS" "acctpass"
+  assert_eq "$MY_ACCOUNT" "acctvalue"
+
+  # Test: account variable not required when not requested
+  unset MY_USER MY_PASS
+  load_netrc --file .netrc api.example.com MY_USER MY_PASS 2>/dev/null
+  assert_eq "$MY_USER" "testuser"
+  assert_eq "$MY_PASS" "testpass123"
+
+  # Test: account variable requested but not present should fail
+  unset MY_USER MY_PASS MY_ACCOUNT
+  if load_netrc --file .netrc api.example.com MY_USER MY_PASS MY_ACCOUNT 2>/dev/null; then
+    echo "Expected load_netrc to fail when account_var requested but no account in netrc"
+    return 1
+  fi
+
+  # Test: --file=<path> form
+  unset MY_USER MY_PASS
+  load_netrc --file=.netrc api.example.com MY_USER MY_PASS 2>/dev/null
+  assert_eq "$MY_USER" "testuser"
+  assert_eq "$MY_PASS" "testpass123"
+
+  # Test: load default entry explicitly
+  unset MY_USER MY_PASS
+  load_netrc --file .netrc default MY_USER MY_PASS 2>/dev/null
+  assert_eq "$MY_USER" "defaultuser"
+  assert_eq "$MY_PASS" "defaultpass"
+
+  # Test: default entry should not be used for unknown machines
+  unset MY_USER MY_PASS
+  if load_netrc --file .netrc unknown.example.com MY_USER MY_PASS 2>/dev/null; then
+    echo "Expected load_netrc to fail for machine only in default block"
+    return 1
+  fi
+
+  # Test: default ~/.netrc path
+  # shellcheck disable=SC2031
+  cp .netrc "$HOME/.netrc"
+  unset MY_USER MY_PASS
+  load_netrc api.example.com MY_USER MY_PASS 2>/dev/null
+  assert_eq "$MY_USER" "testuser"
+  assert_eq "$MY_PASS" "testpass123"
+
+  # Test: missing required argument should fail
+  if load_netrc --file .netrc "" MY_USER MY_PASS 2>/dev/null; then
+    echo "Expected load_netrc to fail for missing machine argument"
+    return 1
+  fi
+
+  # Test: missing netrc file should fail
+  if load_netrc --file missing.netrc api.example.com MY_USER MY_PASS 2>/dev/null; then
+    echo "Expected load_netrc to fail for missing netrc file"
+    return 1
+  fi
+
+  # Test: --file without path should fail
+  if load_netrc --file 2>/dev/null; then
+    echo "Expected load_netrc to fail for --file without path"
+    return 1
+  fi
+
+  # Test: missing machine in file should fail
+  unset MY_USER MY_PASS
+  if load_netrc --file .netrc nonexistent.com MY_USER MY_PASS 2>/dev/null; then
+    echo "Expected load_netrc to fail for nonexistent machine"
+    return 1
+  fi
+
+  # Test: only login (no password) should fail
+  cat > .netrc_nopw << 'EOF'
+machine nopw.example.com
+  login nopwuser
+EOF
+  if load_netrc --file .netrc_nopw nopw.example.com MY_USER MY_PASS 2>/dev/null; then
+    echo "Expected load_netrc to fail for machine with no password"
+    return 1
+  fi
+
+  # Test: macdef inside a machine block should not leak into parsing
+  cat > .netrc_macdef << 'EOF'
+machine other.example.com
+login otheruser
+password otherpass
+macdef upload
+put myfile
+
+machine target.example.com
+login targetuser
+password targetpass
+EOF
+  unset MY_USER MY_PASS
+  load_netrc --file .netrc_macdef target.example.com MY_USER MY_PASS 2>/dev/null
+  assert_eq "$MY_USER" "targetuser"
+  assert_eq "$MY_PASS" "targetpass"
+
+  # Test: keyword-like values (login is "machine", password is "login")
+  cat > .netrc_tricky << 'EOF'
+machine tricky.example.com login machine password login
+EOF
+  unset MY_USER MY_PASS
+  load_netrc --file .netrc_tricky tricky.example.com MY_USER MY_PASS 2>/dev/null
+  assert_eq "$MY_USER" "machine"
+  assert_eq "$MY_PASS" "login"
+
+  # Test: keyword and value split across lines
+  cat > .netrc_split << 'EOF'
+machine
+split.example.com
+login
+splituser
+password
+splitpass
+EOF
+  unset MY_USER MY_PASS
+  load_netrc --file .netrc_split split.example.com MY_USER MY_PASS 2>/dev/null
+  assert_eq "$MY_USER" "splituser"
+  assert_eq "$MY_PASS" "splitpass"
 )
 
 


### PR DESCRIPTION
This PR adds a new `load_netrc` function to the stdlib that loads credentials from [netrc](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) files into environment variables.

> [!NOTE]
> I used Claude Sonnet 4.5 to help me generate the code, tests, and documentation for this new function. However, I have carefully reviewed, made changes, and tested it.
