### PR TITLE
fix(use_nix): unset structured attribute variables

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1292,6 +1292,8 @@ use_nodenv() {
 use_nix() {
   local -A values_to_restore=(
     ["NIX_BUILD_TOP"]=${NIX_BUILD_TOP:-__UNSET__}
+    ["NIX_ATTRS_JSON_FILE"]=${NIX_ATTRS_JSON_FILE:-__UNSET__}
+    ["NIX_ATTRS_SH_FILE"]=${NIX_ATTRS_SH_FILE:-__UNSET__}
     ["TMP"]=${TMP:-__UNSET__}
     ["TMPDIR"]=${TMPDIR:-__UNSET__}
     ["TEMP"]=${TEMP:-__UNSET__}


### PR DESCRIPTION
Much like other variables in this list, the `NIX_ATTRS_JSON_FILE` and `NIX_ATTRS_SH_FILE` variables point to files that do not exist after the Nix shell is destroyed.

This is especially problematic as `NIX_ATTRS_JSON_FILE` is used [in the stdenv setup](https://github.com/NixOS/nixpkgs/blob/7d530a34dd71041f5065d4c4f71dd4cfaf633afe/pkgs/stdenv/generic/setup.sh#L28C13-L28C32), leading to immediate crashes when entering nested non-pure shells for non-structuredAttrs derivations.

Unset these variables to work around this issue.

CC @Mic92