### PR TITLE
fix: find `direnv` from PATH over absolute path in shell installation hook

### DIFF
--- a/internal/cmd/shell_bash.go
+++ b/internal/cmd/shell_bash.go
@@ -10,7 +10,7 @@ var Bash Shell = bash{}
 const bashHook = `
 _direnv_hook() {
   local previous_exit_status=$?;
-  vars="$("{{.SelfPath}}" export bash)";
+  vars="$(direnv export bash)";
   trap -- '' SIGINT;
   eval "$vars";
   trap - SIGINT;

--- a/internal/cmd/shell_elvish.go
+++ b/internal/cmd/shell_elvish.go
@@ -14,7 +14,7 @@ func (elvish) Hook() (string, error) {
 	return `## hook for direnv
 set @edit:before-readline = $@edit:before-readline {
 	try {
-		var m = [("{{.SelfPath}}" export elvish | from-json)]
+		var m = [("direnv" export elvish | from-json)]
 		if (> (count $m) 0) {
 			set m = (all $m)
 			keys $m | each { |k|

--- a/internal/cmd/shell_fish.go
+++ b/internal/cmd/shell_fish.go
@@ -12,14 +12,14 @@ var Fish Shell = fish{}
 
 const fishHook = `
     function __direnv_export_eval --on-event fish_prompt;
-        "{{.SelfPath}}" export fish | source;
+        direnv export fish | source;
 
         if test "$direnv_fish_mode" != "disable_arrow";
             function __direnv_cd_hook --on-variable PWD;
                 if test "$direnv_fish_mode" = "eval_after_arrow";
                     set -g __direnv_export_again 0;
                 else;
-                    "{{.SelfPath}}" export fish | source;
+                    direnv export fish | source;
                 end;
             end;
         end;
@@ -28,7 +28,7 @@ const fishHook = `
     function __direnv_export_eval_2 --on-event fish_preexec;
         if set -q __direnv_export_again;
             set -e __direnv_export_again;
-            "{{.SelfPath}}" export fish | source;
+            direnv export fish | source;
             echo;
         end;
 

--- a/internal/cmd/shell_murex.go
+++ b/internal/cmd/shell_murex.go
@@ -11,7 +11,7 @@ type murex struct{}
 var Murex Shell = murex{}
 
 const murexHook = `event: onPrompt direnv_hook=before {
-	"{{.SelfPath}}" export murex -> set exports
+	"direnv" export murex -> set exports
 	if { $exports != "" } {
 		$exports -> :json: formap key value {
 			if { is-null value } then {

--- a/internal/cmd/shell_pwsh.go
+++ b/internal/cmd/shell_pwsh.go
@@ -20,7 +20,7 @@ if ($PSVersionTable.PSVersion.Major -lt 7 -or ($PSVersionTable.PSVersion.Major -
 $hook = [EventHandler[LocationChangedEventArgs]] {
   param([object] $source, [LocationChangedEventArgs] $eventArgs)
   end {
-    $export = ({{.SelfPath}} export pwsh) -join [Environment]::NewLine;
+    $export = (direnv export pwsh) -join [Environment]::NewLine;
     if ($export) {
       Invoke-Expression -Command $export;
     }

--- a/internal/cmd/shell_tcsh.go
+++ b/internal/cmd/shell_tcsh.go
@@ -11,7 +11,7 @@ type tcsh struct{}
 var Tcsh Shell = tcsh{}
 
 func (sh tcsh) Hook() (string, error) {
-	return "alias precmd 'eval `{{.SelfPath}} export tcsh`'", nil
+	return "alias precmd 'eval `direnv export tcsh`'", nil
 }
 
 func (sh tcsh) Export(e ShellExport) (string, error) {

--- a/internal/cmd/shell_zsh.go
+++ b/internal/cmd/shell_zsh.go
@@ -8,7 +8,7 @@ var Zsh Shell = zsh{}
 
 const zshHook = `
 _direnv_hook() {
-  vars="$("{{.SelfPath}}" export zsh)"
+  vars="$(direnv export zsh)"
   trap -- '' SIGINT
   eval "$vars"
   trap - SIGINT


### PR DESCRIPTION
fixes #1447