### PR TITLE
build: make PREFIX customizable on makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@
 ############################################################################
 
 # Set this to change the target installation path
-PREFIX   = /usr/local
+PREFIX   ?= /usr/local
 BINDIR   = ${PREFIX}/bin
 SHAREDIR = ${PREFIX}/share
 MANDIR   = ${SHAREDIR}/man


### PR DESCRIPTION
it was not possible to customize installation directory unless manually overwriting GNUmakefile. makes PREFIX default to /usr/local if no env var is set.
