### PR TITLE
fish: update fish_complete_path when XDG_DATA_DIRS changes

### DIFF
--- a/test/scenarios/fish-completions/.envrc
+++ b/test/scenarios/fish-completions/.envrc
@@ -1,0 +1,1 @@
+export XDG_DATA_DIRS="$PWD/data:${XDG_DATA_DIRS:-/usr/share}"

--- a/test/scenarios/fish-completions/data/fish/vendor_completions.d/__direnv_test_cmd.fish
+++ b/test/scenarios/fish-completions/data/fish/vendor_completions.d/__direnv_test_cmd.fish
@@ -1,0 +1,2 @@
+# Dummy completion file for testing direnv fish_complete_path integration
+complete -c __direnv_test_cmd -d "Test command for direnv"


### PR DESCRIPTION
## Summary

Fish builds `fish_complete_path` at startup from `XDG_DATA_DIRS`. When direnv later modifies `XDG_DATA_DIRS`, fish doesn't update `fish_complete_path`, so completions from packages added via direnv don't work.

This PR adds a `__direnv_update_fish_complete_path` function to the fish hook that:
- Tracks which completion paths were added by direnv
- Removes stale paths when leaving a directory
- Adds new paths from `$dir/fish/vendor_completions.d`

The function is called explicitly after each `direnv export fish | source` because fish's `--on-variable` event doesn't fire for variables set via `source`.

## Testing

- Automated test added (`test/scenarios/fish-completions/`)
- Tested manually on NixOS

Fixes #1539