### PR TITLE
readme: Add Japanese translation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ confusing for users:
    of shells. It also means that aliases and functions are not exportable
    right now.
 
+### Translations
+
+The direnv documentation is also available in other languages:
+
+* [日本語 (Japanese)](https://gemmaro.github.io/direnv/)
+
 ## Contributing
 
 Bug reports, contributions and forks are welcome. All bugs or other forms of


### PR DESCRIPTION
Hello,

This merge request adds a link to the Japanese translation of the direnv documentation to the README.

Thank you!
