### PR TITLE
Fix `direnv reload` doing nothing after `direnv deny`

### DIFF
--- a/internal/cmd/cmd_reload.go
+++ b/internal/cmd/cmd_reload.go
@@ -17,6 +17,10 @@ var CmdReload = &Cmd{
 			return fmt.Errorf(".envrc not found")
 		}
 
+		if foundRC.Allowed() == Denied {
+			return fmt.Errorf(notAllowed, foundRC.Path())
+		}
+
 		return foundRC.Touch()
 	}),
 }


### PR DESCRIPTION
Currently, when you run `direnv reload` after `direnv deny` it silently fails (exit 0 with no messages) making it unclear what state you are in:

```
$ direnv deny
$ direnv reload
$ echo $?
0
```

With this PR:

```
$ direnv deny
$ direnv reload
direnv: error /Users/enzime/Code/.envrc is blocked. Run `direnv allow` to approve its content
$ echo $?
1
```