### PR TITLE
Allow for named pipes in env file check

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -239,7 +239,7 @@ dotenv() {
     path=$path/.env
   fi
   watch_file "$path"
-  if ! [[ -f $path ]]; then
+  if ! [[ -f $path || -p $path ]]; then
     log_error ".env at $path not found"
     return 1
   fi
@@ -258,7 +258,7 @@ dotenv_if_exists() {
     path=$path/.env
   fi
   watch_file "$path"
-  if ! [[ -f $path ]]; then
+  if ! [[ -f $path || -p $path ]]; then
     return
   fi
   eval "$("$direnv" dotenv bash "$@")"


### PR DESCRIPTION
This allows named pipes as the allowed file types. Mounted .env files from 1password come in the form of named pipes.