### PR TITLE
fix: preserve environment when .envrc evaluation is canceled with CTRL-C

### DIFF
--- a/internal/cmd/cmd_export.go
+++ b/internal/cmd/cmd_export.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -91,6 +93,10 @@ func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 	} else {
 		newEnv, err = config.EnvFromRC(toLoad, previousEnv)
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				logStatus(config, "canceled, preserving environment")
+				return nil
+			}
 			logDebug("err: %v", err)
 			// If loading fails, fall through and deliver a diff anyway,
 			// but still exit with an error.  This prevents retrying on

--- a/internal/cmd/rc.go
+++ b/internal/cmd/rc.go
@@ -288,6 +288,10 @@ func (rc *RC) Load(previousEnv Env) (newEnv Env, err error) {
 		}
 	}
 
+	if ctx.Err() != nil {
+		err = fmt.Errorf("load canceled: %w", ctx.Err())
+	}
+
 	return
 }
 


### PR DESCRIPTION
Previously when interrupted with CTRL-C, direnv returned the clear baseline environment to the shell hooks, effectively deactivating it. It is more convenient and less surprising behavior to instead fall back to the currently active state and retry updating the environment on the next prompt. One can always run `direnv deny` to explicitly get out from an environment.

Fixes #1417 

---

Open questions:

- [ ] Currently each new prompt tries to re-evaluate the environment that can be aborted with CTRL-C. I don't know if this is a feasible idea. I could update the watch state on CTRL-C requiring an explicit `direnv reload` to get to an updated environment.
- [ ] It may be helpful to add a tracking environment variable indicating that the current environment is outdated. Probably can be done a follow-up PR if you think this would be cool to have.
