### PR TITLE
[1548] FIX: Unload environment on delete

### DIFF
--- a/internal/cmd/cmd_export.go
+++ b/internal/cmd/cmd_export.go
@@ -47,7 +47,7 @@ func exportCommand(currentEnv Env, args []string, config *Config) (err error) {
 	loadedRC := config.LoadedRC()
 	toLoad := findEnvUp(config.WorkDir, config.LoadDotenv)
 
-	if loadedRC == nil && toLoad == "" {
+	if loadedRC == nil && toLoad == "" && currentEnv[DIRENV_DIFF] == "" {
 		return
 	}
 

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -280,6 +280,19 @@ if has python; then
   test_stop
 fi
 
+test_start "deleted-envrc"
+  direnv_eval
+  test_eq "$HELLO" "world"
+
+  echo "Deleting .envrc (env should be unloaded on next eval)"
+  cp .envrc .envrc.bak
+  rm .envrc
+  direnv_eval
+  test -z "${HELLO}"
+
+  mv .envrc.bak .envrc
+test_stop
+
 test_start "aliases"
   direnv deny
   # check that allow/deny aliases work

--- a/test/direnv-test-common.sh
+++ b/test/direnv-test-common.sh
@@ -34,7 +34,20 @@ direnv_eval() {
 }
 
 test_start() {
-  cd "$TEST_DIR/scenarios/$1"
+  local isolated=false
+  if [[ "$2" == "isolated" ]]; then
+    isolated=true
+  fi
+
+  if [[ "$isolated" == false ]]; then
+    cd "$TEST_DIR/scenarios/$1"
+  else
+    export DIRENV_TEST_DIR=$(mktemp -d)
+
+    trap '[[ -n "$DIRENV_TEST_DIR" ]] && rm -r "$DIRENV_TEST_DIR"' EXIT
+    cp -r "$TEST_DIR/scenarios/$1" "$DIRENV_TEST_DIR"
+    cd "$DIRENV_TEST_DIR/$1"
+  fi
   direnv allow
   if [[ "$DIRENV_DEBUG" == "1" ]]; then
     echo
@@ -49,6 +62,12 @@ test_stop() {
   rm -f "${XDG_CONFIG_HOME}/direnv/direnv.toml"
   cd /
   direnv_eval
+  if [[ -n "$DIRENV_TEST_DIR" ]]; then
+    trap - EXIT
+
+    rm -r "$DIRENV_TEST_DIR"
+    unset DIRENV_TEST_DIR
+  fi
 }
 
 test_eq() {
@@ -95,6 +114,16 @@ test_start base
   test -z "${HELLO}"
 
   unset WATCHES
+test_stop
+
+test_start rm isolated
+  direnv_eval
+  test_eq "$HELLO" "world"
+
+  echo "Removing .envrc (should unload)"
+  mv .envrc .envrc.old
+  direnv_eval
+  test_eq "$HELLO" ""
 test_stop
 
 test_start inherit

--- a/test/direnv-test.zsh
+++ b/test/direnv-test.zsh
@@ -1,3 +1,4 @@
 #!/usr/bin/env zsh
+setopt posixtraps
 export TARGET_SHELL=zsh
 source "$(dirname $0)/direnv-test-common.sh"

--- a/test/scenarios/deleted-envrc/.envrc
+++ b/test/scenarios/deleted-envrc/.envrc
@@ -1,0 +1,1 @@
+export HELLO=world

--- a/test/scenarios/rm/.envrc
+++ b/test/scenarios/rm/.envrc
@@ -1,0 +1,1 @@
+export HELLO=world


### PR DESCRIPTION
## Fix: unload environment when `.envrc` is deleted

Addresses https://github.com/direnv/direnv/issues/1548.

When a loaded `.envrc` is deleted, direnv fails to unload the environment on the next prompt eval (or on `cd` out of the directory).

**Root cause:** In `cmd_export.go`, the early-return guard was:

```go
if loadedRC == nil && toLoad == "" {
    return
}
```

Meanwhile `DIRENV_DIFF` is still set in the shell from the previous load, so the exported variables remain in the environment indefinitely.

### Changes

- Extend the early-return guard to also require`DIRENV_DIFF` to be unset

## Testing

- Added test scenario for deleted `.envrc`
