### PR TITLE
feat: Add DIRENV_EXE_PATH env variable

### DIFF
--- a/internal/cmd/cmd_hook.go
+++ b/internal/cmd/cmd_hook.go
@@ -28,10 +28,19 @@ func cmdHookAction(_ Env, args []string) (err error) {
 		target = args[1]
 	}
 
-	selfPath, err := os.Executable()
-	if err != nil {
-		return err
+	// Prefer DIRENV_EXE_PATH if set
+	selfPath := os.Getenv("DIRENV_EXE_PATH")
+	if selfPath == "" {
+		selfPath, err = os.Executable()
+		if err != nil {
+			return err
+		}
 	}
+
+	// selfPath, err := os.Executable()
+	// if err != nil {
+	// 	return err
+	// }
 
 	// Convert Windows path if needed
 	selfPath = strings.ReplaceAll(selfPath, "\\", "/")

--- a/internal/cmd/cmd_hook.go
+++ b/internal/cmd/cmd_hook.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 	"text/template"
 )
 
@@ -18,33 +17,17 @@ var CmdHook = &Cmd{
 	Name:   "hook",
 	Desc:   "Used to setup the shell hook",
 	Args:   []string{"SHELL"},
-	Action: actionSimple(cmdHookAction),
+	Action: actionWithConfig(cmdHookAction),
 }
 
-func cmdHookAction(_ Env, args []string) (err error) {
+func cmdHookAction(_ Env, args []string, config *Config) (err error) {
 	var target string
 
 	if len(args) > 1 {
 		target = args[1]
 	}
 
-	// Prefer DIRENV_EXE_PATH if set
-	selfPath := os.Getenv("DIRENV_EXE_PATH")
-	if selfPath == "" {
-		selfPath, err = os.Executable()
-		if err != nil {
-			return err
-		}
-	}
-
-	// selfPath, err := os.Executable()
-	// if err != nil {
-	// 	return err
-	// }
-
-	// Convert Windows path if needed
-	selfPath = strings.ReplaceAll(selfPath, "\\", "/")
-	ctx := HookContext{selfPath}
+	ctx := HookContext{config.SelfPath}
 
 	shell := DetectShell(target)
 	if shell == nil {

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -101,10 +101,15 @@ func LoadConfig(env Env) (config *Config, err error) {
 	}
 
 	var exePath string
-	if exePath, err = os.Executable(); err != nil {
-		err = fmt.Errorf("LoadConfig() os.Executable() failed: %w", err)
-		return
-	}
+	// Check env variable first
+	if envPath := os.Getenv("DIRENV_EXE_PATH"); envPath != "" {
+		exePath = envPath
+	} else {
+		if exePath, err = os.Executable(); err != nil {
+			err = fmt.Errorf("LoadConfig() os.Executable() failed: %w", err)
+			return
+		}
+	}	
 	// Fix for mingsys
 	exePath = strings.ReplaceAll(exePath, "\\", "/")
 	config.SelfPath = exePath


### PR DESCRIPTION
Add support for an environment variable `DIRENV_EXE_PATH`, which allows setting the executable path to something other than os.Executable.

The use case is extremely niche:

When creating a [nix-wrapper package](https://www.youtube.com/watch?v=Zzvn9uYjQJY)
 to bundle direnv's configuration (everything within `$XDG_CONFIG_HOME/direnv`) inside a wrapped direnv package, the direnv executable should be the wrapper (a Bash script that injects `DIRENV_CONFIG` and calls direnv with all arguments passed through), rather than the actual direnv executable. Otherwise, the wrapped configuration will not be picked up.

Despite the highly specific nature of this feature, I believe this PR is worthwhile to consider because:

- The feature is completely backward compatible: if `DIRENV_EXE_PATH` is unset, os.Executable is still used.
- It reduces code duplication by injecting Config into CmdHook.
- It is concise and does not introduce any technical debt.

Please let me know if this has any chance of being merged, and I will update the documentation and unit tests accordingly.