### PR TITLE
Makefile: skip -linkmode=external when CGO_ENABLED=0

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -49,9 +49,11 @@ clean: ## Remove build artifacts
 GO_LDFLAGS =
 
 ifeq ($(shell uname), Darwin)
+  ifneq ($(CGO_ENABLED), 0)
 	# Fixes DYLD_INSERT_LIBRARIES issues
 	# See https://github.com/direnv/direnv/issues/194
 	GO_LDFLAGS += -linkmode=external
+  endif
 endif
 
 ifdef BASH_PATH


### PR DESCRIPTION
Go 1.26 now errors on -linkmode=external when CGO_ENABLED=0, instead of silently ignoring it. Only add the flag when cgo is enabled.