### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/direnv/direnv/v2
 
-go 1.24
+go 1.26.2
 
 require (
 	github.com/BurntSushi/toml v1.5.0


### PR DESCRIPTION
A simple AI check revealed a potential issue with older versions of Go that have known security vulnerabilities. While it may or may not affect their specific setup, it’s still a good practice to use up-to-date software.

I checked the repo with:

  go test ./... - passed
  go list -m all - resolved dependencies successfully
  govulncheck ./... and govulncheck -show verbose ./... - found vulnerabilities
  gosec ./... - found static-analysis findings

  Security vulnerabilities found:

  1. GO-2026-4947 - crypto/x509, fixed in Go 1.26.2
  2. GO-2026-4946 - crypto/x509, fixed in Go 1.26.2
  3. GO-2026-4870 - crypto/tls, fixed in Go 1.26.2
  4. GO-2026-4866 - crypto/x509, fixed in Go 1.26.2

  These are reachable standard-library vulnerabilities from the local build toolchain: go1.26.1. The repo’s listed third-
  party modules did not show reachable dependency vulnerabilities. The practical fix is to build/test with Go 1.26.2 or
  newer, then rerun govulncheck.

  Additional gosec findings: 20 total. Most are static-analysis warnings around expected direnv behavior, such as reading
  user-supplied paths and metadata files. The notable one is internal/cmd/cmd_dump.go:35, an int -> uintptr conversion for
  file descriptors. Others include path traversal warnings in internal/cmd/rc.go, internal/cmd/cmd_prune.go, internal/cmd/
  cmd_dotenv.go, and internal/cmd/cmd_apply_dump.go.