### PR TITLE
Run modernize happy

### DIFF
--- a/gzenv/gzenv.go
+++ b/gzenv/gzenv.go
@@ -8,13 +8,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"io"
+	"log"
 	"strings"
 )
 
 // Marshal encodes the object into the gzenv format
-func Marshal(obj interface{}) string {
+func Marshal(obj any) string {
 	jsonData, err := json.Marshal(obj)
 
 	if err != nil {
@@ -35,7 +35,7 @@ func Marshal(obj interface{}) string {
 }
 
 // Unmarshal restores the gzenv format back into a Go object
-func Unmarshal(gzenv string, obj interface{}) error {
+func Unmarshal(gzenv string, obj any) error {
 	gzenv = strings.TrimSpace(gzenv)
 
 	data, err := base64.URLEncoding.DecodeString(gzenv)

--- a/internal/cmd/cmd_allow.go
+++ b/internal/cmd/cmd_allow.go
@@ -103,8 +103,8 @@ func allowRequiredFiles(rcPath, requiredPaths string, config *Config) error {
 		return fmt.Errorf("failed to create allowed-required directory: %w", err)
 	}
 
-	paths := strings.Split(requiredPaths, ":")
-	for _, relPath := range paths {
+	paths := strings.SplitSeq(requiredPaths, ":")
+	for relPath := range paths {
 		absPath := filepath.Join(rcDir, relPath)
 
 		hash, err := fileHash(absPath)

--- a/internal/cmd/cmd_show_dump.go
+++ b/internal/cmd/cmd_show_dump.go
@@ -22,7 +22,7 @@ func cmdShowDumpAction(_ Env, args []string) (err error) {
 		return fmt.Errorf("missing DUMP argument")
 	}
 
-	var f interface{}
+	var f any
 	err = gzenv.Unmarshal(args[1], &f)
 	if err != nil {
 		return err

--- a/internal/cmd/cmd_status.go
+++ b/internal/cmd/cmd_status.go
@@ -18,28 +18,28 @@ var CmdStatus = &Cmd{
 			if err != nil {
 				return err
 			}
-			jsonOutput := map[string]interface{}{
+			jsonOutput := map[string]any{
 				"config": map[string]string{
 					"SelfPath":  config.SelfPath,
 					"ConfigDir": config.ConfDir,
 				},
-				"state": map[string]interface{}{},
+				"state": map[string]any{},
 			}
 			if loadedRC != nil {
-				jsonOutput["state"].(map[string]interface{})["loadedRC"] = map[string]interface{}{
+				jsonOutput["state"].(map[string]any)["loadedRC"] = map[string]any{
 					"path":    loadedRC.path,
 					"allowed": loadedRC.Allowed(),
 				}
 			} else {
-				jsonOutput["state"].(map[string]interface{})["loadedRC"] = nil
+				jsonOutput["state"].(map[string]any)["loadedRC"] = nil
 			}
 			if foundRC != nil {
-				jsonOutput["state"].(map[string]interface{})["foundRC"] = map[string]interface{}{
+				jsonOutput["state"].(map[string]any)["foundRC"] = map[string]any{
 					"path":    foundRC.path,
 					"allowed": foundRC.Allowed(),
 				}
 			} else {
-				jsonOutput["state"].(map[string]interface{})["foundRC"] = nil
+				jsonOutput["state"].(map[string]any)["foundRC"] = nil
 			}
 			jsonBytes, err := json.MarshalIndent(jsonOutput, "", "  ")
 			if err != nil {

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"maps"
 	"os"
 	"strings"
 
@@ -62,9 +63,7 @@ func LoadEnvJSON(jsonBytes []byte) (env Env, err error) {
 func (env Env) Copy() Env {
 	newEnv := make(Env)
 
-	for key, value := range env {
-		newEnv[key] = value
-	}
+	maps.Copy(newEnv, env)
 
 	return newEnv
 }

--- a/internal/cmd/env_diff.go
+++ b/internal/cmd/env_diff.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"maps"
 	"strings"
 
 	"github.com/direnv/direnv/v2/gzenv"
@@ -106,17 +107,13 @@ func (diff *EnvDiff) ToShell(shell Shell) (string, error) {
 func (diff *EnvDiff) Patch(env Env) (newEnv Env) {
 	newEnv = make(Env)
 
-	for k, v := range env {
-		newEnv[k] = v
-	}
+	maps.Copy(newEnv, env)
 
 	for key := range diff.Prev {
 		delete(newEnv, key)
 	}
 
-	for key, value := range diff.Next {
-		newEnv[key] = value
-	}
+	maps.Copy(newEnv, diff.Next)
 
 	return newEnv
 }

--- a/internal/cmd/file_times_test.go
+++ b/internal/cmd/file_times_test.go
@@ -38,11 +38,11 @@ func TestRoundTrip(t *testing.T) {
 	rtChk := NewFileTimes()
 	_ = rtChk.Unmarshal(watches.Marshal())
 
-	compareFTs(t, watches, rtChk, "length", func(ft FileTimes) interface{} { return len(*ft.list) })
-	compareFTs(t, watches, rtChk, "first path", func(ft FileTimes) interface{} { return (*ft.list)[0].Path })
+	compareFTs(t, watches, rtChk, "length", func(ft FileTimes) any { return len(*ft.list) })
+	compareFTs(t, watches, rtChk, "first path", func(ft FileTimes) any { return (*ft.list)[0].Path })
 }
 
-func compareFTs(t *testing.T, left, right FileTimes, desc string, compare func(ft FileTimes) (res interface{})) {
+func compareFTs(t *testing.T, left, right FileTimes, desc string, compare func(ft FileTimes) (res any)) {
 	lc, rc := compare(left), compare(right)
 	if lc != rc {
 		t.Error("FileTimes didn't round trip.",

--- a/internal/cmd/log.go
+++ b/internal/cmd/log.go
@@ -24,7 +24,7 @@ func setupLogging(env Env) {
 	}
 }
 
-func logError(c *Config, msg string, a ...interface{}) {
+func logError(c *Config, msg string, a ...any) {
 	if c.LogColor {
 		logMsg(defaultLogFormat, msg, a...)
 	} else {
@@ -32,7 +32,7 @@ func logError(c *Config, msg string, a ...interface{}) {
 	}
 }
 
-func logStatus(c *Config, msg string, a ...interface{}) {
+func logStatus(c *Config, msg string, a ...any) {
 	format := c.LogFormat
 	shouldLog := true
 	if c.LogFilter != nil {
@@ -47,7 +47,7 @@ func logStatus(c *Config, msg string, a ...interface{}) {
 	}
 }
 
-func logDebug(msg string, a ...interface{}) {
+func logDebug(msg string, a ...any) {
 	if !debugging {
 		return
 	}
@@ -57,7 +57,7 @@ func logDebug(msg string, a ...interface{}) {
 	_ = log.Output(2, msg)
 }
 
-func logMsg(format, msg string, a ...interface{}) {
+func logMsg(format, msg string, a ...any) {
 	defer log.SetFlags(log.Flags())
 	defer log.SetPrefix(log.Prefix())
 	log.SetFlags(0)

--- a/internal/cmd/look_path.go
+++ b/internal/cmd/look_path.go
@@ -18,7 +18,7 @@ func lookPath(file string, pathenv string) (string, error) {
 	if pathenv == "" {
 		return "", errNotFound
 	}
-	for _, dir := range strings.Split(pathenv, ":") {
+	for dir := range strings.SplitSeq(pathenv, ":") {
 		if dir == "" {
 			// Unix shell semantics: path element "" means "."
 			dir = "."

--- a/internal/cmd/shell_bash.go
+++ b/internal/cmd/shell_bash.go
@@ -1,5 +1,7 @@
 package cmd
 
+import "strings"
+
 import "fmt"
 
 type bash struct{}
@@ -30,23 +32,23 @@ func (sh bash) Hook() (string, error) {
 }
 
 func (sh bash) Export(e ShellExport) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range e {
 		if value == nil {
-			out += sh.unset(key)
+			out.WriteString(sh.unset(key))
 		} else {
-			out += sh.export(key, *value)
+			out.WriteString(sh.export(key, *value))
 		}
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh bash) Dump(env Env) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range env {
-		out += sh.export(key, value)
+		out.WriteString(sh.export(key, value))
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh bash) export(key, value string) string {

--- a/internal/cmd/shell_fish.go
+++ b/internal/cmd/shell_fish.go
@@ -41,32 +41,33 @@ func (sh fish) Hook() (string, error) {
 }
 
 func (sh fish) Export(e ShellExport) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range e {
 		if value == nil {
-			out += sh.unset(key)
+			out.WriteString(sh.unset(key))
 		} else {
-			out += sh.export(key, *value)
+			out.WriteString(sh.export(key, *value))
 		}
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh fish) Dump(env Env) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range env {
-		out += sh.export(key, value)
+		out.WriteString(sh.export(key, value))
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh fish) export(key, value string) string {
 	if key == "PATH" {
-		command := "set -x -g PATH"
-		for _, path := range strings.Split(value, ":") {
-			command += " " + sh.escape(path)
+		var command strings.Builder
+		command.WriteString("set -x -g PATH")
+		for path := range strings.SplitSeq(value, ":") {
+			command.WriteString(" " + sh.escape(path))
 		}
-		return command + ";"
+		return command.String() + ";"
 	}
 	return "set -x -g " + sh.escape(key) + " " + sh.escape(value) + ";"
 }

--- a/internal/cmd/shell_pwsh.go
+++ b/internal/cmd/shell_pwsh.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 )
 
 type pwsh struct{}
@@ -39,25 +40,25 @@ else {
 }
 
 func (sh pwsh) Export(e ShellExport) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range e {
 		if key != "" {
 			if value == nil {
-				out += sh.unset(key)
+				out.WriteString(sh.unset(key))
 			} else {
-				out += sh.export(key, *value)
+				out.WriteString(sh.export(key, *value))
 			}
 		}
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh pwsh) Dump(env Env) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range env {
-		out += sh.export(key, value)
+		out.WriteString(sh.export(key, value))
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh pwsh) export(key, value string) string {

--- a/internal/cmd/shell_systemd.go
+++ b/internal/cmd/shell_systemd.go
@@ -17,21 +17,21 @@ func (sh systemdShell) Hook() (string, error) {
 }
 
 func (sh systemdShell) Export(e ShellExport) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range e {
 		if value != nil {
-			out += sh.export(key, *value)
+			out.WriteString(sh.export(key, *value))
 		}
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh systemdShell) Dump(env Env) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range env {
-		out += sh.export(key, value)
+		out.WriteString(sh.export(key, value))
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func cutEncapsulated(valueToTest, encapsulatingValue string) (cutValue string, wasEncapsulated bool) {

--- a/internal/cmd/shell_tcsh.go
+++ b/internal/cmd/shell_tcsh.go
@@ -15,32 +15,33 @@ func (sh tcsh) Hook() (string, error) {
 }
 
 func (sh tcsh) Export(e ShellExport) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range e {
 		if value == nil {
-			out += sh.unset(key)
+			out.WriteString(sh.unset(key))
 		} else {
-			out += sh.export(key, *value)
+			out.WriteString(sh.export(key, *value))
 		}
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh tcsh) Dump(env Env) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range env {
-		out += sh.export(key, value)
+		out.WriteString(sh.export(key, value))
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh tcsh) export(key, value string) string {
 	if key == "PATH" {
-		command := "set path = ("
-		for _, path := range strings.Split(value, ":") {
-			command += " " + sh.escape(path)
+		var command strings.Builder
+		command.WriteString("set path = (")
+		for path := range strings.SplitSeq(value, ":") {
+			command.WriteString(" " + sh.escape(path))
 		}
-		return command + " );"
+		return command.String() + " );"
 	}
 	return "setenv " + sh.escape(key) + " " + sh.escape(value) + " ;"
 }

--- a/internal/cmd/shell_vim.go
+++ b/internal/cmd/shell_vim.go
@@ -15,23 +15,23 @@ func (sh vim) Hook() (string, error) {
 }
 
 func (sh vim) Export(e ShellExport) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range e {
 		if value == nil {
-			out += sh.unset(key)
+			out.WriteString(sh.unset(key))
 		} else {
-			out += sh.export(key, *value)
+			out.WriteString(sh.export(key, *value))
 		}
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh vim) Dump(env Env) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range env {
-		out += sh.export(key, value)
+		out.WriteString(sh.export(key, value))
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh vim) export(key, value string) string {

--- a/internal/cmd/shell_zsh.go
+++ b/internal/cmd/shell_zsh.go
@@ -1,5 +1,7 @@
 package cmd
 
+import "strings"
+
 // ZSH is a singleton instance of ZSH_T
 type zsh struct{}
 
@@ -28,23 +30,23 @@ func (sh zsh) Hook() (string, error) {
 }
 
 func (sh zsh) Export(e ShellExport) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range e {
 		if value == nil {
-			out += sh.unset(key)
+			out.WriteString(sh.unset(key))
 		} else {
-			out += sh.export(key, *value)
+			out.WriteString(sh.export(key, *value))
 		}
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh zsh) Dump(env Env) (string, error) {
-	var out string
+	var out strings.Builder
 	for key, value := range env {
-		out += sh.export(key, value)
+		out.WriteString(sh.export(key, value))
 	}
-	return out, nil
+	return out.String(), nil
 }
 
 func (sh zsh) export(key, value string) string {

--- a/pkg/dotenv/parse.go
+++ b/pkg/dotenv/parse.go
@@ -47,7 +47,7 @@ func Parse(data string) (map[string]string, error) {
 	var multilineValue string
 	var quoteChar byte
 
-	for i := 0; i < len(lines); i++ {
+	for i := range lines {
 		line := lines[i]
 
 		// Continue collecting a multi-line value
@@ -180,12 +180,12 @@ func expandEnv(value string, dotenv map[string]string) string {
 }
 
 func splitKeyAndDefault(value string, sep string) (string, string, bool) {
-	var i = strings.Index(value, sep)
+	var before, after, ok = strings.Cut(value, sep)
 
-	if i == -1 {
+	if !ok {
 		return value, "", false
 	}
-	return value[0:i], value[i+len(sep):], true
+	return before, after, true
 }
 
 func lookupDotenv(value string, dotenv map[string]string) (string, bool) {


### PR DESCRIPTION
SSIA.

```console
$ go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@v0.21.1 -test ./...
/Users/zchee/go/src/github.com/direnv/direnv/gzenv/gzenv.go:17:18: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/gzenv/gzenv.go:38:34: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/cmd_show_dump.go:25:8: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/cmd_status.go:21:29: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/cmd_status.go:26:25: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/cmd_status.go:29:37: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/cmd_status.go:29:75: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/cmd_status.go:34:37: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/cmd_status.go:37:37: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/cmd_status.go:37:74: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/cmd_status.go:42:37: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/log.go:27:43: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/log.go:35:44: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/log.go:50:32: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/log.go:60:38: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/file_times_test.go:41:61: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/file_times_test.go:42:65: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/file_times_test.go:45:99: interface{} can be replaced by any
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/env.go:66:3: Replace m[k]=v loop with maps.Copy
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/env_diff.go:110:3: Replace m[k]=v loop with maps.Copy
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/env_diff.go:118:3: Replace m[k]=v loop with maps.Copy
/Users/zchee/go/src/github.com/direnv/direnv/pkg/dotenv/parse.go:50:6: for loop can be modernized using range over int
/Users/zchee/go/src/github.com/direnv/direnv/pkg/dotenv/parse.go:183:10: strings.Index can be simplified using strings.Cut
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/cmd_allow.go:106:11: Ranging over SplitSeq is more efficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/look_path.go:21:22: Ranging over SplitSeq is more efficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_fish.go:66:24: Ranging over SplitSeq is more efficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_tcsh.go:40:24: Ranging over SplitSeq is more efficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_fish.go:67:4: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_pwsh.go:46:5: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_bash.go:36:4: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_fish.go:58:3: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_systemd.go:23:4: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_vim.go:32:3: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_zsh.go:45:3: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_systemd.go:32:3: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_tcsh.go:41:4: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_vim.go:21:4: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_zsh.go:34:4: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_fish.go:47:4: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_pwsh.go:58:3: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_tcsh.go:21:4: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_tcsh.go:32:3: using string += string in a loop is inefficient
/Users/zchee/go/src/github.com/direnv/direnv/internal/cmd/shell_bash.go:47:3: using string += string in a loop is inefficient
```