### PR TITLE
Fix ANSI escapes on dumb terminals

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -120,6 +120,7 @@ func LoadConfig(env Env) (config *Config, err error) {
 
 	// Default log format
 	config.LogFormat = defaultLogFormat
+	config.LogColor = termSupportsANSI(env)
 
 	config.RCFile = env[DIRENV_FILE]
 
@@ -149,8 +150,6 @@ func LoadConfig(env Env) (config *Config, err error) {
 			err = fmt.Errorf("LoadConfig() failed to parse %s: %w", config.TomlPath, err)
 			return
 		}
-
-		config.LogColor = os.Getenv("TERM") != "dumb"
 
 		format, ok := env["DIRENV_LOG_FORMAT"]
 		if ok {

--- a/internal/cmd/log.go
+++ b/internal/cmd/log.go
@@ -14,6 +14,10 @@ const (
 
 var debugging bool
 
+func termSupportsANSI(env Env) bool {
+	return env.Fetch("TERM", "") != "dumb"
+}
+
 func setupLogging(env Env) {
 	log.SetFlags(0)
 	log.SetPrefix("")
@@ -26,9 +30,9 @@ func setupLogging(env Env) {
 
 func logError(c *Config, msg string, a ...interface{}) {
 	if c.LogColor {
-		logMsg(defaultLogFormat, msg, a...)
-	} else {
 		logMsg(errorColor+defaultLogFormat+clearColor, msg, a...)
+	} else {
+		logMsg(defaultLogFormat, msg, a...)
 	}
 }
 
@@ -40,9 +44,9 @@ func logStatus(c *Config, msg string, a ...interface{}) {
 	}
 	if shouldLog && format != "" {
 		if c.LogColor {
-			logMsg(format, msg, a...)
-		} else {
 			logMsg(fmt.Sprintf("%s%s", clearColor, format), msg, a...)
+		} else {
+			logMsg(format, msg, a...)
 		}
 	}
 }

--- a/internal/cmd/log_test.go
+++ b/internal/cmd/log_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureLogOutput(t *testing.T, fn func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	origWriter := log.Writer()
+	origFlags := log.Flags()
+	origPrefix := log.Prefix()
+
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	log.SetPrefix("")
+	t.Cleanup(func() {
+		log.SetOutput(origWriter)
+		log.SetFlags(origFlags)
+		log.SetPrefix(origPrefix)
+	})
+
+	fn()
+
+	return buf.String()
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() {
+		os.Stderr = origStderr
+	})
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing stderr writer failed: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("reading captured stderr failed: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("closing stderr reader failed: %v", err)
+	}
+
+	return buf.String()
+}
+
+func TestLoadConfigSetsLogColorFromTERM(t *testing.T) {
+	t.Run("ansi terminal", func(t *testing.T) {
+		baseDir := t.TempDir()
+		cfg, err := LoadConfig(Env{
+			"DIRENV_CONFIG": baseDir + "/config",
+			"HOME":          baseDir,
+			"TERM":          "xterm-256color",
+		})
+		if err != nil {
+			t.Fatalf("LoadConfig returned error: %v", err)
+		}
+		if !cfg.LogColor {
+			t.Fatalf("expected LogColor to be enabled for ANSI-capable terminals")
+		}
+	})
+
+	t.Run("dumb terminal", func(t *testing.T) {
+		baseDir := t.TempDir()
+		cfg, err := LoadConfig(Env{
+			"DIRENV_CONFIG": baseDir + "/config",
+			"HOME":          baseDir,
+			"TERM":          "dumb",
+		})
+		if err != nil {
+			t.Fatalf("LoadConfig returned error: %v", err)
+		}
+		if cfg.LogColor {
+			t.Fatalf("expected LogColor to be disabled for dumb terminals")
+		}
+	})
+}
+
+func TestMainSkipsAnsiForTopLevelErrorsOnDumbTerminals(t *testing.T) {
+	out := captureStderr(t, func() {
+		err := Main(Env{"TERM": "dumb"}, []string{"direnv", "export", "nosuchshell"}, "", "", "")
+		if err == nil {
+			t.Fatal("expected Main to return an error for an unknown shell")
+		}
+	})
+	if strings.Contains(out, "\033[") {
+		t.Fatalf("expected top-level error without ANSI escapes, got %q", out)
+	}
+}
+
+func TestLogStatusUsesAnsiOnlyWhenEnabled(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		out := captureLogOutput(t, func() {
+			logStatus(&Config{LogColor: true, LogFormat: defaultLogFormat}, "loading test")
+		})
+		if !strings.Contains(out, clearColor) {
+			t.Fatalf("expected status log to reset color when enabled, got %q", out)
+		}
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		out := captureLogOutput(t, func() {
+			logStatus(&Config{LogColor: false, LogFormat: defaultLogFormat}, "loading test")
+		})
+		if strings.Contains(out, "\033[") {
+			t.Fatalf("expected status log without ANSI escapes, got %q", out)
+		}
+	})
+}
+
+func TestLogErrorUsesAnsiOnlyWhenEnabled(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		out := captureLogOutput(t, func() {
+			logError(&Config{LogColor: true}, "boom")
+		})
+		if !strings.Contains(out, errorColor) {
+			t.Fatalf("expected error log to include ANSI color when enabled, got %q", out)
+		}
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		out := captureLogOutput(t, func() {
+			logError(&Config{LogColor: false}, "boom")
+		})
+		if strings.Contains(out, "\033[") {
+			t.Fatalf("expected error log without ANSI escapes, got %q", out)
+		}
+	})
+}

--- a/internal/cmd/mod.go
+++ b/internal/cmd/mod.go
@@ -24,7 +24,11 @@ func Main(env Env, args []string, modBashPath string, modStdlib string, modVersi
 
 	err := CommandsDispatch(env, args)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%sdirenv: error %v%s\n", errorColor, err, clearColor)
+		if termSupportsANSI(env) {
+			fmt.Fprintf(os.Stderr, "%sdirenv: error %v%s\n", errorColor, err, clearColor)
+		} else {
+			fmt.Fprintf(os.Stderr, "direnv: error %v\n", err)
+		}
 	}
 	return err
 }


### PR DESCRIPTION
Fixes #1551.

Before this change, `TERM=dumb` still let ANSI escapes leak into stderr output:

- `direnv export bash` prefixed status logs with `^[[0m`
- `direnv export nosuchshell` printed ANSI escapes on the top-level error path

After this change, dumb terminals get plain stderr output while ANSI-capable terminals keep the existing reset/error coloring.

Validation:
- `go test ./internal/cmd -run 'TestLoadConfigSetsLogColorFromTERM|TestMainSkipsAnsiForTopLevelErrorsOnDumbTerminals|TestLogStatusUsesAnsiOnlyWhenEnabled|TestLogErrorUsesAnsiOnlyWhenEnabled' -count=1`
- `go test ./... -count=1`
- manual repro with a fresh built binary for both `export bash` and `export nosuchshell`
