### PR TITLE
use_flox needs to use -c option to honor profile hooks

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1410,7 +1410,7 @@ function use_flox() {
         return 1
     fi
 
-    direnv_load flox activate "${args[@]}" -- "$direnv" dump
+    direnv_load flox activate "${args[@]}" -c "$direnv dump"
 
     if [[ ${#args[@]} -eq 0 ]]; then
         watch_dir "$flox_dir/env/"


### PR DESCRIPTION
With the changed behavior for flox activate in the [1.9.0 release](https://github.com/flox/flox/releases/tag/v1.9.0) my direnv based workflow broke, which was initially promoted in this [blog-post](https://flox.dev/popular-packages/auto-environment-activation-with-direnv-flox/). This is because the direnv `use_flox` command indead uses
```
flox activate -- <cmd>
```
which now does not call the `[profile]` hooks anymore (see [here](https://github.com/direnv/direnv/blob/b00e451f547f39be7ab836d969054114a465a0f9/stdlib.sh#L1413)). The hook previously did automatically activate a Python virtual environment, which now does not work anymore.

See [here](https://github.com/flox/flox/issues/4174)