### PR TITLE
man/direnv-fetchurl fix whatis declaration

### DIFF
--- a/man/direnv-fetchurl.1
+++ b/man/direnv-fetchurl.1
@@ -1,7 +1,7 @@
 .nh
 .TH DIRENV-FETCHURL 1 "2019" direnv "User Manuals"
 .SH NAME
-direnv fetchurl \- Fetch a URL to disk
+direnv-fetchurl \- Fetch a URL to disk
 
 .SH SYNOPSIS
 \fIdirenv fetchurl\fP  []

--- a/man/direnv-fetchurl.1.md
+++ b/man/direnv-fetchurl.1.md
@@ -4,7 +4,7 @@ DIRENV-FETCHURL 1 "2019" direnv "User Manuals"
 NAME
 ----
 
-direnv fetchurl - Fetch a URL to disk
+direnv-fetchurl - Fetch a URL to disk
 
 SYNOPSIS
 --------


### PR DESCRIPTION
ref: https://lintian.debian.org/tags/bad-whatis-entry.html

this will change
```
% whatis 1 direnv-fetchurl
direnv-fetchurl (1)  - (unknown subject)
```
to
```
% whatis 1 direnv-fetchurl
direnv-fetchurl (1)  - Fetch a URL to disk
```
