### PR TITLE
ZSH chpwd hook

### DIFF
--- a/internal/cmd/shell_zsh.go
+++ b/internal/cmd/shell_zsh.go
@@ -8,6 +8,13 @@ var Zsh Shell = zsh{}
 
 const zshHook = `
 _direnv_hook() {
+  # break if chpwd is triggered by e.g. a completion call.
+  # ref: src:zsh/Functions/Chpwd/chpwd_recent_dirs
+  if [[ ! -o interactive  || $ZSH_SUBSHELL -ne 0 || \
+    ( -n $ZSH_EVAL_CONTEXT && \
+    $ZSH_EVAL_CONTEXT != toplevel(:[a-z]#func|)# ) ]]; then
+    return
+  fi
   vars="$("{{.SelfPath}}" export zsh)"
   trap -- '' SIGINT
   eval "$vars"


### PR DESCRIPTION
Prevent execution of hook when triggered by any subprocesses like completion calls which can trigger a chpwd which will not change our cwd.

---

I ran into this problem when using `ssh` which evidently ran a `cd` for completing hostnames.

The first call was with a hostname which can't be resolved, the second with a valid hostname.
```
% ssh moodirenv: unloading                                                                               :(
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
                                          ssh moo                                                                                                :(
% ssh knedirenv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
direnv: unloading
ipix.de
```

The chpwd was triggered by the following line:
https://github.com/zsh-users/zsh/blob/40625a597581e8d3fd3dc8dc71a97d6e15c57242/Completion/Unix/Type/_ssh_hosts#L39

Changing the `cd $HOME` to `cd -q $HOME` already resolved the issue but i was told from the zsh-developers that the hook shouldn't be triggered by the shown calls and pointed me to https://github.com/zsh-users/zsh/blob/40625a597581e8d3fd3dc8dc71a97d6e15c57242/Functions/Chpwd/chpwd_recent_dirs#L32-L36 where i _stole_ this test.