### PR TITLE
Use `-c` instead of `--` for `use_flox`

### DIFF
--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1410,7 +1410,7 @@ function use_flox() {
         return 1
     fi
 
-    direnv_load flox activate "${args[@]}" -- "$direnv" dump
+    direnv_load flox activate "${args[@]}" -c "$direnv dump"
 
     if [[ ${#args[@]} -eq 0 ]]; then
         watch_dir "$flox_dir/env/"


### PR DESCRIPTION
Flox 1.9.0 replaced the behavior of `--` with that of `-c`, and `--` no longer runs profile scripts. Use `-c` to go back to the old behavior

Closes https://github.com/direnv/direnv/pull/1581