### PR TITLE
feat(dotenv): add named pipe (FIFO) support for 1Password Environments

### DIFF
--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -35,10 +35,14 @@ expand_path ../foo
 .EE
 
 .SS \fBdotenv [<dotenv_path>]\fR
-Loads a ".env" file into the current environment.
+Loads a ".env" file into the current environment. The file may be a regular
+file or a named pipe (FIFO), e.g. one mounted by a secrets manager such as
+1Password Environments to inject secrets without writing the secret contents to
+disk. Named pipes are not watched for changes.
 
 .SS \fBdotenv_if_exists [<dotenv_path>]\fR
-Loads a ".env" file into the current environment, but only if it exists.
+Loads a ".env" file into the current environment, but only if it exists. As with
+\fBdotenv\fR, the file may be a regular file or a named pipe (FIFO).
 
 .SS \fBuser_rel_path <abs_path>\fR
 Transforms an absolute path \fIabs_path\fP into a user-relative path if possible.

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -41,11 +41,15 @@ Example:
 
 ### `dotenv [<dotenv_path>]`
 
-Loads a ".env" file into the current environment.
+Loads a ".env" file into the current environment. The file may be a regular
+file or a named pipe (FIFO), e.g. one mounted by a secrets manager such as
+1Password Environments to inject secrets without writing the secret contents to
+disk. Named pipes are not watched for changes.
 
 ### `dotenv_if_exists [<dotenv_path>]`
 
-Loads a ".env" file into the current environment, but only if it exists.
+Loads a ".env" file into the current environment, but only if it exists. As with
+`dotenv`, the file may be a regular file or a named pipe (FIFO).
 
 ### `user_rel_path <abs_path>`
 

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -244,7 +244,7 @@ dotenv() {
   # Watch regular files (and not-yet-existing paths) so changes trigger a reload.
   # Never watch a named pipe: its mtime changes every time it is read, which would
   # force a reload on every prompt.
-  if [[ ! -p $path ]]; then
+  if [[ -f $path || ! -e $path ]]; then
     watch_file "$path"
   fi
   if ! [[ -f $path || -p $path ]]; then
@@ -269,7 +269,7 @@ dotenv_if_exists() {
   # Watch regular files (and not-yet-existing paths) so changes trigger a reload.
   # Never watch a named pipe: its mtime changes every time it is read, which would
   # force a reload on every prompt.
-  if [[ ! -p $path ]]; then
+  if [[ -f $path || ! -e $path ]]; then
     watch_file "$path"
   fi
   if ! [[ -f $path || -p $path ]]; then

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -229,7 +229,10 @@ realpath.absolute() {
 
 # Usage: dotenv [<dotenv>]
 #
-# Loads a ".env" file into the current environment
+# Loads a ".env" file into the current environment. The file may be a regular
+# file or a named pipe (FIFO), e.g. one mounted by a secrets manager such as
+# 1Password Environments to inject secrets without writing the secret contents
+# to disk.
 #
 dotenv() {
   local path=${1:-}
@@ -238,8 +241,13 @@ dotenv() {
   elif [[ -d $path ]]; then
     path=$path/.env
   fi
-  watch_file "$path"
-  if ! [[ -f $path ]]; then
+  # Watch regular files (and not-yet-existing paths) so changes trigger a reload.
+  # Never watch a named pipe: its mtime changes every time it is read, which would
+  # force a reload on every prompt.
+  if [[ ! -p $path ]]; then
+    watch_file "$path"
+  fi
+  if ! [[ -f $path || -p $path ]]; then
     log_error ".env at $path not found"
     return 1
   fi
@@ -248,7 +256,8 @@ dotenv() {
 
 # Usage: dotenv_if_exists [<filename>]
 #
-# Loads a ".env" file into the current environment, but only if it exists.
+# Loads a ".env" file into the current environment, but only if it exists. The
+# file may be a regular file or a named pipe (FIFO).
 #
 dotenv_if_exists() {
   local path=${1:-}
@@ -257,8 +266,13 @@ dotenv_if_exists() {
   elif [[ -d $path ]]; then
     path=$path/.env
   fi
-  watch_file "$path"
-  if ! [[ -f $path ]]; then
+  # Watch regular files (and not-yet-existing paths) so changes trigger a reload.
+  # Never watch a named pipe: its mtime changes every time it is read, which would
+  # force a reload on every prompt.
+  if [[ ! -p $path ]]; then
+    watch_file "$path"
+  fi
+  if ! [[ -f $path || -p $path ]]; then
     return
   fi
   eval "$("$direnv" dotenv bash "$@")"

--- a/test/stdlib.bash
+++ b/test/stdlib.bash
@@ -69,6 +69,16 @@ test_name "dotenv / dotenv_if_exists (named pipe / FIFO)"
   # shellcheck disable=SC2064
   trap '[[ -n $writer_pid ]] && kill "$writer_pid" 2>/dev/null; rm -rf "$workdir"' EXIT
 
+  # Reap the background writer without ever hanging the suite: a writer blocked on
+  # opening the FIFO for write (e.g. if the reader never opened it) is bounded-waited,
+  # then killed. The EXIT trap is the final backstop.
+  reap_writer() {
+    for _ in $(seq 1 50); do kill -0 "$writer_pid" 2>/dev/null || break; sleep 0.1; done
+    kill "$writer_pid" 2>/dev/null || true
+    wait "$writer_pid" 2>/dev/null || true
+    writer_pid=""
+  }
+
   cd "$workdir"
 
   # Positive control: watch_file is functional in this harness, so the no-watch
@@ -88,7 +98,7 @@ test_name "dotenv / dotenv_if_exists (named pipe / FIFO)"
   ( echo "export FOO=bar" > fifo.env ) &
   writer_pid=$!
   dotenv fifo.env
-  wait "$writer_pid"; writer_pid=""
+  reap_writer
   [[ $FOO = bar ]]
   # ... and must NOT add the FIFO to the watch list: a FIFO's mtime changes on
   # every read, which would otherwise force a reload on every prompt.
@@ -100,7 +110,7 @@ test_name "dotenv / dotenv_if_exists (named pipe / FIFO)"
   ( echo "export FOO=baz" > fifo.env ) &
   writer_pid=$!
   dotenv_if_exists fifo.env
-  wait "$writer_pid"; writer_pid=""
+  reap_writer
   [[ $FOO = baz ]]
   assert_eq "${DIRENV_WATCHES:-}" "$before"
 )

--- a/test/stdlib.bash
+++ b/test/stdlib.bash
@@ -60,6 +60,51 @@ test_name dotenv_if_exists
   [[ $FOO = bar ]]
 )
 
+test_name "dotenv / dotenv_if_exists (named pipe / FIFO)"
+(
+  load_stdlib
+
+  workdir=$(mktemp -d)
+  writer_pid=""
+  # shellcheck disable=SC2064
+  trap '[[ -n $writer_pid ]] && kill "$writer_pid" 2>/dev/null; rm -rf "$workdir"' EXIT
+
+  cd "$workdir"
+
+  # Positive control: watch_file is functional in this harness, so the no-watch
+  # assertions below are meaningful (watching a regular file changes DIRENV_WATCHES).
+  before=${DIRENV_WATCHES:-}
+  : > regular.txt
+  watch_file regular.txt
+  [[ ${DIRENV_WATCHES:-} != "$before" ]] || { echo "watch_file did not record a regular file"; return 1; }
+
+  # A ".env" provided as a named pipe (FIFO) - as mounted by secrets managers
+  # like 1Password Environments to inject secrets on read, without writing the
+  # secret contents to disk. The writer blocks until dotenv opens the pipe.
+  mkfifo fifo.env
+
+  # dotenv loads the FIFO ...
+  before=${DIRENV_WATCHES:-}
+  ( echo "export FOO=bar" > fifo.env ) &
+  writer_pid=$!
+  dotenv fifo.env
+  wait "$writer_pid"; writer_pid=""
+  [[ $FOO = bar ]]
+  # ... and must NOT add the FIFO to the watch list: a FIFO's mtime changes on
+  # every read, which would otherwise force a reload on every prompt.
+  assert_eq "${DIRENV_WATCHES:-}" "$before"
+
+  # dotenv_if_exists shares the same gate, so it must load a FIFO too.
+  unset FOO
+  before=${DIRENV_WATCHES:-}
+  ( echo "export FOO=baz" > fifo.env ) &
+  writer_pid=$!
+  dotenv_if_exists fifo.env
+  wait "$writer_pid"; writer_pid=""
+  [[ $FOO = baz ]]
+  assert_eq "${DIRENV_WATCHES:-}" "$before"
+)
+
 test_name find_up
 (
   load_stdlib


### PR DESCRIPTION
## Summary

`dotenv` and `dotenv_if_exists` reject a `.env` that is a **named pipe (FIFO)**: the
guard `[[ -f $path ]]` only accepts regular files, so a FIFO (`-p`) is reported as
`.env … not found` and nothing is loaded.

This matters when a secrets manager mounts the `.env` as a FIFO to inject secrets on
read **without ever writing their contents to disk** — e.g. [1Password Environments](https://developer.1password.com/docs/environment/).
This change accepts named pipes in addition to regular files in both stdlib functions.

## Prior art

This mirrors the equivalent change I made to oh-my-zsh's `dotenv` plugin, which was
merged: ohmyzsh/ohmyzsh#13561 ("add named pipe (FIFO) support for 1Password
Environments"). direnv has the same one-line file-type guard — plus a `watch_file`
consideration the shell plugin doesn't have (handled below).

## What changed

- `dotenv()` / `dotenv_if_exists()` accept `-p` (FIFO) in addition to `-f`.
- A FIFO is **not** passed to `watch_file`: a FIFO's mtime changes on every read, so
  watching it would force a reload on every prompt. Regular files and not-yet-existing
  paths are still watched — their behavior (including reload-when-created) is unchanged.
- No Go change: `direnv dotenv` (`os.ReadFile`) already reads FIFOs to EOF correctly.

## Scope & notes

- Scoped to the explicit `dotenv` / `dotenv_if_exists` stdlib calls. `load_dotenv = true`
  auto-discovery uses a different Go path (`fileExists` → `os.Open` + `Mode().IsRegular()`)
  and is intentionally out of scope.
- The FIFO producer must write the env and then close (EOF), since the read drains to EOF.
- Pre-existing / unchanged: when the argument is a directory it is normalized to
  `<dir>/.env` for the guard and `watch_file`, but the original argument is still passed
  to `direnv dotenv`. A directory *containing* a FIFO `.env` is an exotic case not
  addressed here.

## Testing

- New `test/stdlib.bash` case covering **both** `dotenv` and `dotenv_if_exists` with a
  FIFO: asserts the value loads and that the FIFO is **not** added to `DIRENV_WATCHES`
  (with a positive control proving `watch_file` records a regular file in the harness).
- `make build` and the stdlib test suite pass; man page (`.1.md` + regenerated roff)
  updated.
