### PR TITLE
Add Korn shell (ksh) support

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -112,7 +112,8 @@ tests = \
 				test-tcsh \
 				test-zsh \
 				test-pwsh \
-				test-mx
+				test-mx \
+				test-ksh
 
 # Skip few checks for IBM Z mainframe's z/OS aka OS/390
 ifeq ($(shell uname), OS/390)
@@ -162,6 +163,9 @@ test-pwsh:
 
 test-mx:
 	murex -trypipe ./test/direnv-test.mx
+
+test-ksh:
+	ksh ./test/direnv-test.ksh
 
 ############################################################################
 # Installation

--- a/internal/cmd/shell.go
+++ b/internal/cmd/shell.go
@@ -44,6 +44,7 @@ var supportedShellList = map[string]Shell{
 	"zsh":     Zsh,
 	"pwsh":    Pwsh,
 	"systemd": Systemd,
+	"ksh":     Ksh,
 }
 
 // DetectShell returns a Shell instance from the given target.

--- a/internal/cmd/shell_ksh.go
+++ b/internal/cmd/shell_ksh.go
@@ -1,0 +1,100 @@
+package cmd
+
+import "strings"
+
+type ksh struct{}
+
+// Korn shell instance
+var Ksh Shell = ksh{}
+
+const kshHook = `
+_direnv_hook() {
+  local previous_exit_status=$?;
+  vars="$("{{.SelfPath}}" export ksh)";
+  trap -- '' SIGINT;
+  eval "$vars";
+  trap - SIGINT;
+  return $previous_exit_status;
+};
+if [[ ";${PROMPT_COMMAND[*]:-};" != *";_direnv_hook;"* ]]; then
+  if [[ "$(declare -p PROMPT_COMMAND 2>&1)" == "declare -a"* ]]; then
+    PROMPT_COMMAND=(_direnv_hook "${PROMPT_COMMAND[@]}")
+  else
+    PROMPT_COMMAND="_direnv_hook${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+  fi
+fi
+`
+
+func (sh ksh) Hook() (string, error) {
+	return kshHook, nil
+}
+
+func (sh ksh) Export(e ShellExport) (string, error) {
+	var out strings.Builder
+	for key, value := range e {
+		if value == nil {
+			out.WriteString(sh.unset(key))
+		} else {
+			out.WriteString(sh.export(key, *value))
+		}
+	}
+	return out.String(), nil
+}
+
+func (sh ksh) Dump(env Env) (string, error) {
+	var out strings.Builder
+	for key, value := range env {
+		out.WriteString(sh.export(key, value))
+	}
+	return out.String(), nil
+}
+
+func (sh ksh) export(key, value string) string {
+	return "export " + sh.escape(key) + "=" + sh.escape(value) + ";"
+}
+
+func (sh ksh) unset(key string) string {
+	return "unset " + sh.escape(key) + ";"
+}
+
+func (sh ksh) escape(str string) string {
+	return KshEscape(str)
+}
+
+/*
+ * Escaping
+ */
+
+// See also Quoting section in ksh(1).
+func KshEscape(str string) string {
+	if str == "" {
+		return "''"
+	}
+	in := []byte(str)
+	out := ""
+	i := 0
+	l := len(in)
+
+	backslash := func(char byte) {
+		out += string([]byte{BACKSLASH, char})
+	}
+
+	literal := func(char byte) {
+		out += string([]byte{char})
+	}
+
+	for i < l {
+		char := in[i]
+		switch char {
+		case BACKSLASH, '$', BACKTICK, '"':
+			backslash(char)
+		default:
+			literal(char)
+		}
+		i++
+	}
+
+	out = "\"" + out + "\""
+
+	return out
+}

--- a/test/direnv-test.ksh
+++ b/test/direnv-test.ksh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+export TARGET_SHELL=ksh
+# shellcheck disable=SC1091
+. "$(dirname "$0")/direnv-test-common.sh"


### PR DESCRIPTION
EDIT: It turned out that OpenBSD's ksh doesn't support hook mechanism.  Therefore I'm closing this PR.

Related: #873 

TODO to be ready:

- [ ] fix syntax error in hook script:

      ```bash
      PROMPT_COMMAND=(_direnv_hook "${PROMPT_COMMAND[@]}")
                     ^-- syntax error
      ```

- [ ] make sure that `gmake test-ksh` passes

Currently, "Testing python-layout" section is failing:

<details>

```
$ gmake test-ksh
gmake test-ksh
ksh ./test/direnv-test.ksh
direnv: loading ~/src/_vendor/direnv/test/.envrc
## Testing base ##
Setting up
direnv: loading ~/src/_vendor/direnv/test/scenarios/base/.envrc
direnv: export +HELLO
Reloading (should be no-op)
Updating envrc and reloading (should reload)
direnv: loading ~/src/_vendor/direnv/test/scenarios/base/.envrc
direnv: export +HELLO
Leaving dir (should clear env set by dir's envrc)
direnv: loading ~/src/_vendor/direnv/test/.envrc

direnv: unloading
## Testing inherit ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/inherit/.envrc
direnv: loading ~/src/_vendor/direnv/test/scenarios/inherited/.envrc
world
direnv: export +HELLO
HELLO should be world: world
direnv: loading ~/src/_vendor/direnv/test/scenarios/inherit/.envrc
direnv: loading ~/src/_vendor/direnv/test/scenarios/inherited/.envrc
goodbye
direnv: export +HELLO
direnv: unloading
./test/direnv-test.ksh: type: -P: unknown option
## Testing ruby-layout ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/ruby-layout/.envrc
direnv: export +BUNDLE_BIN +GEM_HOME ~PATH
direnv: unloading
## Testing space dir ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/space dir/.envrc
direnv: export +SPACE_DIR ~PATH
direnv: unloading
## Testing child-env ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/child-env/.envrc
direnv: export +CHILD +PARENT_POST +PARENT_PRE
direnv: unloading
## Testing special-vars ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/special-vars/.envrc
direnv: unloading
## Testing dump ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/dump/.envrc
to stdout
to stderr
direnv: direnv_load would previously hang if DIRENV_DUMP_FILE_PATH was not opened.
direnv: Expect the following to emit an error (which we suppress).
direnv: As long as it doesn't hang, we're okay.
direnv: Environment not dumped; did you invoke 'direnv dump'?
direnv: export +LESSOPEN +LS_COLORS +THREE_BACKSLASHES
direnv: unloading
## Testing empty-var ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/empty-var/.envrc
direnv: export +FOO
direnv: unloading
## Testing empty-var-unset ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/empty-var-unset/.envrc
direnv: export -FOO
direnv: unloading
## Testing in-envrc ##
direnv: loading ~/src/_vendor/direnv/test/.envrc
direnv: unloading
## Testing missing-file-source-env ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/missing-file-source-env/.envrc
direnv: referenced /tmp/6911.5GGbzOFw/.envrc does not exist
direnv: unloading
## Testing symlink-changed ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/symlink-changed/.envrc
direnv: export +STATE
direnv: loading ~/src/_vendor/direnv/test/scenarios/symlink-changed/.envrc
direnv: export +STATE
direnv: unloading
## Testing symlink-dir ##
## Testing utf-8 ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/utf-8/.envrc
direnv: export +UTFSTUFF
direnv: unloading
## Testing failure ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/failure/.envrc
direnv: error exit status 5
direnv: unloading
## Testing watch-dir ##
No watches by default
direnv: loading ~/src/_vendor/direnv/test/scenarios/watch-dir/.envrc
After eval, watches have changed
direnv: unloading
## Testing load-envrc-before-env ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/load-envrc-before-env/.envrc
direnv: export +HELLO
direnv: unloading
## Testing load-env ##
direnv: export +HELLO
direnv: unloading
## Testing skip-env ##
direnv: loading ~/src/_vendor/direnv/test/.envrc
direnv: unloading
./test/direnv-test.ksh: type: -P: unknown option
## Testing python-layout ##
direnv: loading ~/src/_vendor/direnv/test/scenarios/python-layout/.envrc
/usr/local/bin/bash:863: python: command not found
direnv: Could not find python's version
gmake: *** [GNUmakefile:168: test-ksh] Error 1
```

</details>