### PR TITLE
version help: standardize on "no older than"

### DIFF
--- a/internal/cmd/cmd_version.go
+++ b/internal/cmd/cmd_version.go
@@ -10,7 +10,7 @@ import (
 // CmdVersion is `direnv version`
 var CmdVersion = &Cmd{
 	Name:    "version",
-	Desc:    "prints the version or checks that direnv is older than VERSION_AT_LEAST.",
+	Desc:    "prints the version or checks that direnv is no older than VERSION_AT_LEAST.",
 	Args:    []string{"[VERSION_AT_LEAST]"},
 	Aliases: []string{"--version"},
 	Action: actionSimple(func(_ Env, args []string) error {

--- a/man/direnv-stdlib.1
+++ b/man/direnv-stdlib.1
@@ -422,7 +422,7 @@ require_allowed pixi.toml pixi.lock
 .EE
 
 .SS \fBdirenv_version <version_at_least>\fR
-Checks that the direnv version is at least old as \fBversion_at_least\fR\&. This can
+Checks that the direnv version is no older than \fBversion_at_least\fR\&. This can
 be useful when sharing an \fB\&.envrc\fR and to make sure that the users are up to
 date.
 

--- a/man/direnv-stdlib.1.md
+++ b/man/direnv-stdlib.1.md
@@ -404,7 +404,7 @@ Example (.envrc):
 
 ### `direnv_version <version_at_least>`
 
-Checks that the direnv version is at least old as `version_at_least`. This can
+Checks that the direnv version is no older than `version_at_least`. This can
 be useful when sharing an `.envrc` and to make sure that the users are up to
 date.
 

--- a/man/direnv.1
+++ b/man/direnv.1
@@ -168,7 +168,7 @@ Displays the stdlib available in the .envrc execution context.
 
 .TP
 \fBdirenv version\fR
-Prints the version or checks that direnv is older than VERSION_AT_LEAST.
+Prints the version or checks that direnv is no older than VERSION_AT_LEAST.
 
 .SH USAGE
 In some target folder, create an \fB\&.envrc\fR file and add some export(1)

--- a/man/direnv.1.md
+++ b/man/direnv.1.md
@@ -172,7 +172,7 @@ COMMANDS
 : Displays the stdlib available in the .envrc execution context.
 
 `direnv version`
-: Prints the version or checks that direnv is older than VERSION_AT_LEAST.
+: Prints the version or checks that direnv is no older than VERSION_AT_LEAST.
 
 USAGE
 -----

--- a/stdlib.sh
+++ b/stdlib.sh
@@ -1459,7 +1459,7 @@ use_vim() {
 
 # Usage: direnv_version <version_at_least>
 #
-# Checks that the direnv version is at least old as <version_at_least>.
+# Checks that the direnv version is no older than <version_at_least>.
 direnv_version() {
   "$direnv" version "$@"
 }


### PR DESCRIPTION
Previosly the help and the docs used confusing "older than" or "at least old" (sic).

Fixes #1601.